### PR TITLE
fix ReadTheDocs build

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,5 +13,6 @@ python:
   version: 3.7
   install:
     - requirements: requirements.txt
+    - requirements: docs/requirements.txt
     - method: pip
       path: .

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+docutils
+pygments
+m2r

--- a/tox.ini
+++ b/tox.ini
@@ -46,9 +46,7 @@ setenv =
     CI=true
 deps =
   -rrequirements.txt
-  docutils
-  pygments
-  m2r
+  -rdocs/requirements.txt
 basepython = python3.7
 commands_pre =
     # install c7n-mailer, which needs to be from source...


### PR DESCRIPTION
The code changes in #5 [broke the ReadTheDocs build](https://readthedocs.org/projects/manheim-c7n-tools/builds/9251629/) because building docs now requires the ``m2r`` package. Refactor requirements handling for RTD builds so that RTD will properly install the requirements.