### PR TITLE
Pypi readme fix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,12 @@
 Changelog
 =========
 
-0.7.0 (2019-05-28)
+0.7.1 (2019-06-24)
+------------------
+
+* Fix for README not rendering on pypi.org.
+
+0.7.0 (2019-06-24)
 ------------------
 
 * Code migrated from private project/repository to GitHub.com under Apache2 license; first public release.

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ manheim-c7n-tools
 
 [![Docker Hub Build Status](https://img.shields.io/docker/cloud/build/manheim/manheim-c7n-tools.svg)](https://hub.docker.com/r/manheim/manheim-c7n-tools)
 
+[![PyPI Version badge](https://img.shields.io/pypi/v/manheim-c7n-tools.svg)](https://pypi.org/project/manheim-c7n-tools/)
+
 Manheim's Cloud Custodian (c7n) wrapper package, policy generator, runner, and supporting tools.
 
 This project provides common tooling, distributed as a Docker image, for managing Manheim's cloud-custodian (c7n) tooling, including c7n itself, c7n_mailer, and our custom components. This project/repository is intended to be used (generally via the generated Docker image) alongside a configuration repository of a specific layout, containing configuration for one or more AWS accounts.

--- a/manheim_c7n_tools/version.py
+++ b/manheim_c7n_tools/version.py
@@ -17,7 +17,7 @@ manheim-c7n-tools version configuration.
 """
 
 #: The semver-compliant version of the package.
-VERSION = '0.7.0'
+VERSION = '0.7.1'
 
 #: The URL for further information about the package.
 PROJECT_URL = 'https://github.com/manheim/manheim-c7n-tools'

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
     url=PROJECT_URL,
     description='c7n policy generation script and related utilities',
     long_description=long_description,
+    long_description_content_type='text/markdown',
     install_requires=requires,
     keywords="custodian aws c7n policy",
     classifiers=classifiers,


### PR DESCRIPTION
The README / description is broken [on PyPI](https://pypi.org/project/manheim-c7n-tools/) because I omitted the markdown content type. This fixes it.