### PR TITLE
fix unicode encoding error when running under py3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.7.2 (2019-06-24)
+------------------
+
+* Fix error in ``policygen`` script / step when running under Python3.
+
 0.7.1 (2019-06-24)
 ------------------
 

--- a/manheim_c7n_tools/policygen.py
+++ b/manheim_c7n_tools/policygen.py
@@ -530,7 +530,7 @@ class PolicyGen(object):
             os.environ.get('BUILD_NUMBER', ''),
             os.environ.get('BUILD_URL', '')
         )
-        commit = os.environ['GIT_COMMIT']
+        commit = os.environ.get('GIT_COMMIT', 'unknown')
         gitlink = '%scommit/%s' % (git_html_url(), commit)
         if buildinfo == 'by `  <>`_':
             buildinfo = 'locally'

--- a/manheim_c7n_tools/tests/test_utils.py
+++ b/manheim_c7n_tools/tests/test_utils.py
@@ -89,7 +89,7 @@ class TestGitHtmlUrl(object):
             res = git_html_url()
         assert res == 'https://git.example.com/Foo/bar/'
         assert mock_co.mock_calls == [
-            call(['git', 'config', 'remote.origin.url'])
+            call(['git', 'config', 'remote.origin.url'], text=True)
         ]
 
     def test_private_https(self):
@@ -100,7 +100,7 @@ class TestGitHtmlUrl(object):
             res = git_html_url()
         assert res == 'https://git.example.com/Foo/bar/'
         assert mock_co.mock_calls == [
-            call(['git', 'config', 'remote.origin.url'])
+            call(['git', 'config', 'remote.origin.url'], text=True)
         ]
 
     def test_github_git(self):
@@ -111,7 +111,7 @@ class TestGitHtmlUrl(object):
             res = git_html_url()
         assert res == 'https://github.com/Foo/bar/'
         assert mock_co.mock_calls == [
-            call(['git', 'config', 'remote.origin.url'])
+            call(['git', 'config', 'remote.origin.url'], text=True)
         ]
 
     def test_github_https(self):
@@ -122,7 +122,7 @@ class TestGitHtmlUrl(object):
             res = git_html_url()
         assert res == 'https://github.com/Foo/bar/'
         assert mock_co.mock_calls == [
-            call(['git', 'config', 'remote.origin.url'])
+            call(['git', 'config', 'remote.origin.url'], text=True)
         ]
 
     def test_bad_pattern(self):

--- a/manheim_c7n_tools/utils.py
+++ b/manheim_c7n_tools/utils.py
@@ -110,8 +110,11 @@ def git_html_url():
     :rtype: str
     :raises: RuntimeError if the command fails or the URL cannot be parsed
     """
-    p = subprocess.check_output(['git', 'config', 'remote.origin.url'])
+    p = subprocess.check_output(
+        ['git', 'config', 'remote.origin.url'], text=True
+    )
     p = p.strip()
+
     # git / ssh remote
     m = re.match(
         r'^([^@]+)@(?P<hostname>[a-zA-Z0-9_-]+(\.[a-zA-Z0-9_-]+)+):'

--- a/manheim_c7n_tools/version.py
+++ b/manheim_c7n_tools/version.py
@@ -17,7 +17,7 @@ manheim-c7n-tools version configuration.
 """
 
 #: The semver-compliant version of the package.
-VERSION = '0.7.1'
+VERSION = '0.7.2'
 
 #: The URL for further information about the package.
 PROJECT_URL = 'https://github.com/manheim/manheim-c7n-tools'


### PR DESCRIPTION
## Description

There's a bug we hadn't hit in our internal code, where ``policygen`` dies when running under python3 because it tries to use a string regex on a unicode/bytes value. This PR fixes that.

## Testing Done

Unit tests.