### PR TITLE
fix dryrun-diff errors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+0.7.3 (2019-06-25)
+------------------
+
+* Fix ArgumentParser error preventing ``dryrun-diff`` from being run as standalone entrypoint (as opposed to ``manheim-c7n-runner`` step).
+* Fix Python3 error in ``dryrun-diff``.
+
 0.7.2 (2019-06-24)
 ------------------
 

--- a/manheim_c7n_tools/dryrun_diff.py
+++ b/manheim_c7n_tools/dryrun_diff.py
@@ -111,7 +111,7 @@ class DryRunDiffer(object):
         :rtype: str
         """
         all_policies = list(set(
-            dryrun.keys() + self._live_results.keys()
+            list(dryrun.keys()) + list(self._live_results.keys())
         ))
         if len(all_policies) == 0:
             return 'No policy reports found. Perhaps all changed policies ' \
@@ -291,6 +291,8 @@ def parse_args(argv):
     p.add_argument('-c', '--config', dest='config', action='store',
                    default='manheim-c7n-tools.yml',
                    help='Config file path (default: ./manheim-c7n-tools.yml)')
+    p.add_argument('ACCOUNT_NAME', type=str, action='store',
+                   help='Account name in config file, to run diff for')
     args = p.parse_args(argv)
     return args
 
@@ -321,7 +323,7 @@ def main():
     elif args.verbose == 1:
         set_log_info(logger)
 
-    conf = ManheimConfig.from_file(args.config)
+    conf = ManheimConfig.from_file(args.config, args.ACCOUNT_NAME)
     DryRunDiffer(conf).run(
         git_dir=args.git_dir, diff_against=args.diff_against
     )

--- a/manheim_c7n_tools/version.py
+++ b/manheim_c7n_tools/version.py
@@ -17,7 +17,7 @@ manheim-c7n-tools version configuration.
 """
 
 #: The semver-compliant version of the package.
-VERSION = '0.7.2'
+VERSION = '0.7.3'
 
 #: The URL for further information about the package.
 PROJECT_URL = 'https://github.com/manheim/manheim-c7n-tools'


### PR DESCRIPTION
## Description

When running ``dryrun-diff`` locally this morning in a Python3 venv, I found 2 bugs in it: one related to Python3 and one related to running the standalone ``dryrun-diff`` entrypoint vs running it as a step in ``manheim-c7n-runner``. 

## Testing Done

Ran locally; bugs fixed.