### PR TITLE
Update policygen to allow aggregating multiple source paths.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,5 @@ testresults.html
 assets/
 docs/source/.doctrees
 mailer.yml
+.direnv/
+.envrc

--- a/.gitignore
+++ b/.gitignore
@@ -74,3 +74,4 @@ docs/source/.doctrees
 mailer.yml
 .direnv/
 .envrc
+.vscode/

--- a/docs/source/policies.rst
+++ b/docs/source/policies.rst
@@ -98,7 +98,7 @@ Multiple Repository Layout
             └── us-west-2
                 └── policy-four-us-west-2.yml
 
-An example configuration for a multiple repository setup can be seen at `https://github.com/manheim/manheim-c7n-tools/tree/master/example_config_multi_repo <https://github.com/manheim/manheim-c7n-tools/tree/master/example_config_multi_repo>`_.
+.. An example configuration for a multiple repository setup can be seen at `https://github.com/manheim/manheim-c7n-tools/tree/master/example_config_multi_repo <https://github.com/manheim/manheim-c7n-tools/tree/master/example_config_multi_repo>`_.
 
 .. _`policies.region_interpolation`:
 

--- a/docs/source/policies.rst
+++ b/docs/source/policies.rst
@@ -53,6 +53,53 @@ When building the final configuration, policies from the account-specific direct
 
 An example configuration repository can be seen at `https://github.com/manheim/manheim-c7n-tools/tree/master/example_config_repo <https://github.com/manheim/manheim-c7n-tools/tree/master/example_config_repo>`_.
 
+.. _`policies.repo_layout_multi`:
+
+Multiple Repository Layout
+--------------------------
+
+::
+
+    manheim-c7n-tools.yml
+    policies/
+    ├── app
+    │   ├── defaults.yml
+    │   └── ACCOUNT-NAME
+    │       ├── us-east-1
+    │       │   ├── policy-five-us-east-1.yml
+    │       │   └── policy-six-us-east-1.yml
+    │       ├── us-east-2
+    │       │   └── policy-six-us-east-2.yml
+    │       ├── us-west-1
+    │       │   └── policy-six-us-west-1.yml
+    │       └── us-west-2
+    │           └── policy-six-us-west-2.yml
+    ├── common
+    │   ├── all_accounts
+    │   │   └── common
+    │   │       └── policy-one.yml
+    │   ├── defaults.yml
+    │   └── ACCOUNT-NAME
+    │       └── common
+    │           ├── policy-three.yml
+    │           └── policy-two.yml
+    └── team
+        ├── all_accounts
+        │   └── common
+        │       └── policy-six.yml
+        └── ACCOUNT-NAME
+            ├── us-east-1
+            │   ├── policy-five-us-east-1.yml
+            │   └── policy-four-us-east-1.yml
+            ├── us-east-2
+            │   └── policy-four-us-east-2.yml
+            ├── us-west-1
+            │   └── policy-four-us-west-1.yml
+            └── us-west-2
+                └── policy-four-us-west-2.yml
+
+An example configuration for a multiple repository setup can be seen at `https://github.com/manheim/manheim-c7n-tools/tree/master/example_config_multi_repo <https://github.com/manheim/manheim-c7n-tools/tree/master/example_config_multi_repo>`_.
+
 .. _`policies.region_interpolation`:
 
 Policy Interpolation

--- a/docs/source/policygen.rst
+++ b/docs/source/policygen.rst
@@ -76,3 +76,29 @@ Array merging is somewhat special, to let us set defaults for actions:
 -  Any defaults dictionaries not handled under the previous condition
    will be appended to the result, with the exception of a
    ``type: notify`` dictionary in the ``['actions']`` path.
+
+Mutiple Repository Layout
+=========================
+
+In order to facilitate separation of organizational rules from team or account specific rules, the policies directory can contain subdirectories to be merged into a single ruleset. Directories will be merged using the same logic described in the defaults merging documentation. An example of a multi-repository layout is at :ref:`policies.repo_layout`
+
+Config changes for Multiple Repositories
+----------------------------------------
+
+To use multiple subdirectories, the configuration file must be updated with a list of directories that should be considered. Order matters, as preference will be given to repositories lower in the list in the case of conflicting configurations. A new ``policy_source_paths`` configuration option has been added, and should contain a list of subdirectories to consider in the order of least to most specific.
+
+.. code-block:: yaml
+    policy_source_paths:
+      - shared
+      - team
+      - app
+
+Defaults with Multiple Repositories
+-----------------------------------
+
+There can be only one ``defaults.yaml`` file in use. The tool will search all configured repository paths for a ``defaults.yaml`` file at the root of each path in the order specified in the ``policy_source_paths`` option. The last file found will be used. If no ``defaults.yaml`` file is found in the repository paths, it will look in the ``policies`` directory itself. At least one ``defaults.yaml`` must be present.
+
+Overriding rules
+----------------
+
+Overriding rules is based on naming. **Rules will not be merged, only replaced.** If a rule appears in a lower repository it will replace a rule with the same name in a higher repository.

--- a/docs/source/policygen.rst
+++ b/docs/source/policygen.rst
@@ -88,6 +88,7 @@ Config changes for Multiple Repositories
 To use multiple subdirectories, the configuration file must be updated with a list of directories that should be considered. Order matters, as preference will be given to repositories lower in the list in the case of conflicting configurations. A new ``policy_source_paths`` configuration option has been added, and should contain a list of subdirectories to consider in the order of least to most specific.
 
 .. code-block:: yaml
+
     policy_source_paths:
       - shared
       - team

--- a/example_config_multi_repo/README.rst
+++ b/example_config_multi_repo/README.rst
@@ -1,0 +1,18 @@
+manheim-c7n-tools Example Configuration Repo
+============================================
+
+This is an example configuration repository for the `manheim-c7n-tools
+<https://github.com/manheim/manheim-c7n-tools>`_ project. Along with the
+dependencies (IAM Role, S3 Bucket, and CloudWatch Log Group), this repository
+contains an example of all of the configuration required to run
+``manheim-c7n-tools`` for an AWS account.
+
+This repository shows an example of a multi-repo configuration. `policies`
+directory contains several subdirectories - these can be git submodules or
+other means of aggregating several separate rules repositories. Each of these
+will be merged together according to the order specified in the
+`policy_source_paths` configuration value, with lower repos taking precedence
+over higher repos. In order to override a rule, make a copy of the rule from
+another repo and change it to match your needs. Rules are overridden based on
+rule name, but rule configurations themselves are NOT merged, they are
+replaced in their entirety.

--- a/example_config_multi_repo/manheim-c7n-tools.yml
+++ b/example_config_multi_repo/manheim-c7n-tools.yml
@@ -1,0 +1,64 @@
+# This file configures manheim-c7n-tools for one or more AWS accounts.
+# The file itself is an array of one or more per-account maps
+- # Account name, used for output naming and for performing actions on the account
+  account_name: one-account
+  # Account ID / Number
+  account_id: 123456789012
+  # Regions to run custodian and other tooling in for this account
+  regions:
+    - us-east-1
+    - us-east-2
+    - us-west-1
+    - us-west-2
+  policy_source_paths:
+    - shared
+    - team
+    - app
+  # Name of c7n output S3 bucket
+  output_s3_bucket_name: c7n-123456789012-%%AWS_REGION%%
+  # Name of c7n CloudWatch Log Group
+  custodian_log_group: /cloud-custodian/123456789012/%%AWS_REGION%%
+  # ARN of the Dead Letter Queue for the c7n Lambda functions
+  # note the "&foo" syntax is a YAML "Node Anchor"/variable/alias;
+  # we can then use "*foo" later in the document to reference what follows
+  # that anchor/variable
+  dead_letter_queue_arn: &dev_dlq_arn arn:aws:sqs:%%AWS_REGION%%:123456789012:c7n-123456789012-deadletter
+  # IAM Role ARN to run custodian and mailer Lambdas under
+  role_arn: &dev_role_arn arn:aws:iam::123456789012:role/c7n-123456789012
+  # Regions to deploy c7n-mailer into. We generally only deploy it to us-east-1,
+  # since not all regions have SES support.
+  mailer_regions:
+    - us-east-1
+  # Configuration for c7n-mailer; this exactly matches the c7n-mailer YAML config format.
+  mailer_config:
+    # NOTE: mailer only runs in us-east-1, so the queue URL should only be for that region
+    queue_url: https://sqs.us-east-1.amazonaws.com/123456789012/c7n-123456789012
+    role: *dev_role_arn
+    from_address: our-team@example.com
+    region: '%%AWS_REGION%%'
+    dead_letter_config:
+      TargetArn: *dev_dlq_arn
+    contact_tags:
+      - OwnerEmail
+      - ownerEmail
+      - owneremail
+    splunk_hec_url: '%%POLICYGEN_ENV_SPLUNK_URL%%'
+    splunk_hec_token: '%%POLICYGEN_ENV_SPLUNK_TOKEN%%'
+    splunk_remove_paths:
+      - /event/detail/invokingEvent
+      - /event/detail/resultToken
+      - /event/detail/requestParameters
+      - /event/detail/responseElements
+      - /resource/c7n.metrics
+    splunk_actions_list: true
+    splunk_max_attempts: 4
+    splunk_hec_max_length: 10000
+  # Optional setting that ensures EVERY policy has a notify action with this
+  # transport and **at least** these recipients. Used to ensure that EVERY
+  # policy sends logs to the Splunk HEC.
+  always_notify:
+    to:
+      - 'splunkhec://%%POLICYGEN_ENV_SPLUNK_INDEX%%'
+    transport:
+      type: sqs
+      queue: '%%MAILER_QUEUE_URL%%'

--- a/example_config_multi_repo/policies/app/defaults.yml
+++ b/example_config_multi_repo/policies/app/defaults.yml
@@ -1,0 +1,31 @@
+mode:
+  type: periodic
+  # This will trigger our rules at 20:20 UTC (11:20 EDT / 10:20 EST)
+  # This file will take precedence over the one in the top-level policies
+  # folder
+  schedule: 'cron(20 20 * * ? *)'
+  timeout: 500
+  execution-options:
+    log_group: '%%LOG_GROUP%%'
+    output_dir: 's3://%%BUCKET_NAME%%/logs'
+  dead_letter_config:
+    TargetArn: '%%DLQ_ARN%%'
+  role: '%%ROLE_ARN%%'
+  tags:
+    Project: cloud-custodian
+    Environment: '%%ACCOUNT_NAME%%'
+    OwnerEmail: our-team@example.com
+actions:
+  - type: notify
+    questions_email: our-team@example.com
+    questions_slack: releaseengineering
+    template: our-custom-template.html
+    to:
+      - resource-owner
+      - 'splunkhec://%%POLICYGEN_ENV_SPLUNK_INDEX%%'
+    owner_absent_contact:
+      - our-team@example.com
+      - aws-users-distro@example.com
+    transport:
+      type: sqs
+      queue: '%%MAILER_QUEUE_URL%%'

--- a/example_config_multi_repo/policies/app/one-account/us-east-1/ec2-low-utilization-mark.yml
+++ b/example_config_multi_repo/policies/app/one-account/us-east-1/ec2-low-utilization-mark.yml
@@ -1,0 +1,46 @@
+# REMINDER: defaults.yml will be merged in to this. See the README.
+name: ec2-low-utilization-mark
+comment: EC2 Instances with low utilization - notify via email and mark to terminate in 14 days. Look at 2 days worth of data.
+resource: ec2
+filters:
+  # not tagged for this policy; otherwise, we'd just keep pushing the mark date forward
+  - {'tag:c7n-ec2-low-utilization': absent}
+  # instance is running
+  - {State.Name: running}
+  # Instance Type isn't t2.nano or t2.micro
+  - type: value
+    key: "InstanceType"
+    op: not-in
+    value:
+      - "t2.nano"
+      - "t2.micro"
+  # CPUUtilization 15-minute average < 4% over the last day
+  - type: metrics
+    name: CPUUtilization
+    days: 1
+    period: 900
+    statistics: Average
+    value: 4
+    op: less-than
+  # NetworkIn less than 7k per 6-hours over the last day
+  - type: metrics
+    name: NetworkIn
+    days: 1
+    period: 21600
+    statistics: Maximum
+    value: 7000
+    op: less-than
+  # NetworkOut less than 7k per 6-hours over the last day
+  - type: metrics
+    name: NetworkOut
+    days: 1
+    period: 21600
+    statistics: Maximum
+    value: 7000
+    op: less-than
+actions:
+  - type: mark-for-op
+    tag: c7n-ec2-low-utilization
+    msg: "ec2-low-utilization-mark: {op}@{action_date}"
+    op: terminate
+    days: 14

--- a/example_config_multi_repo/policies/defaults.yml
+++ b/example_config_multi_repo/policies/defaults.yml
@@ -1,0 +1,29 @@
+mode:
+  type: periodic
+  # This will trigger our rules at 15:20 UTC (11:20 EDT / 10:20 EST)
+  schedule: 'cron(20 15 * * ? *)'
+  timeout: 300
+  execution-options:
+    log_group: '%%LOG_GROUP%%'
+    output_dir: 's3://%%BUCKET_NAME%%/logs'
+  dead_letter_config:
+    TargetArn: '%%DLQ_ARN%%'
+  role: '%%ROLE_ARN%%'
+  tags:
+    Project: cloud-custodian
+    Environment: '%%ACCOUNT_NAME%%'
+    OwnerEmail: our-team@example.com
+actions:
+  - type: notify
+    questions_email: our-team@example.com
+    questions_slack: releaseengineering
+    template: our-custom-template.html
+    to:
+      - resource-owner
+      - 'splunkhec://%%POLICYGEN_ENV_SPLUNK_INDEX%%'
+    owner_absent_contact:
+      - our-team@example.com
+      - aws-users-distro@example.com
+    transport:
+      type: sqs
+      queue: '%%MAILER_QUEUE_URL%%'

--- a/example_config_multi_repo/policies/shared/all_accounts/common/ami-old-used-report.yml
+++ b/example_config_multi_repo/policies/shared/all_accounts/common/ami-old-used-report.yml
@@ -1,0 +1,9 @@
+# REMINDER: defaults.yml will be merged in to this. See the README.
+name: ami-old-used-report
+resource: ami
+comments: Report on old AMIs that are being used
+filters:
+  - type: image-age
+    days: 90
+  - type: unused
+    value: false

--- a/example_config_multi_repo/policies/shared/one-account/common/c7n-cw-log-retention.yml
+++ b/example_config_multi_repo/policies/shared/one-account/common/c7n-cw-log-retention.yml
@@ -1,0 +1,18 @@
+# REMINDER: defaults.yml will be merged in to this. See the README.
+name: c7n-cw-log-retention
+comments: Ensure CloudWatch Log groups for cloud-custodian have 30-day retention.
+resource: log-group
+filters:
+  # custodian- or cloud-custodian- lambda log groups
+  - type: value
+    key: logGroupName
+    op: regex
+    value: "^/aws/lambda/(cloud-custodian-|custodian-)"
+  - type: value
+    key: retentionInDays
+    op: ne
+    value: 30
+actions:
+  # set Log Group retention to 30 days
+  - type: retention
+    days: 30

--- a/example_config_multi_repo/policies/shared/one-account/common/ebs-attachment-info-tag.yml
+++ b/example_config_multi_repo/policies/shared/one-account/common/ebs-attachment-info-tag.yml
@@ -1,0 +1,13 @@
+# REMINDER: defaults.yml will be merged in to this. See the README.
+name: ebs-attachment-info-tag
+resource: ebs
+comments: Copy tags from EC2 attachments to EBS volume
+filters:
+  - type: value
+    key: "Attachments[0].Device"
+    value: not-null
+actions:
+  - type: copy-instance-tags
+    tags:
+      - Name
+      - ownerEmail

--- a/example_config_multi_repo/policies/team/one-account/common/c7n-cw-log-retention.yml
+++ b/example_config_multi_repo/policies/team/one-account/common/c7n-cw-log-retention.yml
@@ -1,0 +1,20 @@
+# REMINDER: defaults.yml will be merged in to this. See the README.
+# This rule will override the rule with the same namein the shared repo
+# It increases the retention from 30 to 90 days
+name: c7n-cw-log-retention
+comments: Ensure CloudWatch Log groups for cloud-custodian have 30-day retention.
+resource: log-group
+filters:
+  # custodian- or cloud-custodian- lambda log groups
+  - type: value
+    key: logGroupName
+    op: regex
+    value: "^/aws/lambda/(cloud-custodian-|custodian-)"
+  - type: value
+    key: retentionInDays
+    op: ne
+    value: 90
+actions:
+  # set Log Group retention to 30 days
+  - type: retention
+    days: 90

--- a/example_config_multi_repo/policies/team/one-account/common/ebs-unattached-delete.yml
+++ b/example_config_multi_repo/policies/team/one-account/common/ebs-unattached-delete.yml
@@ -1,0 +1,14 @@
+# REMINDER: defaults.yml will be merged in to this. See the README.
+name: ebs-unattached-delete
+resource: ebs
+comments: Snapshot, notify about, then delete unattached EBS volumes
+filters:
+  - Attachments: []
+  - State: available
+actions:
+  - snapshot
+  - delete
+  - type: notify
+    violation_desc: EBS volumes were found unattached
+    action_desc: These EBS volumes were snapshotted and then deleted
+    subject: '[cloud-custodian {{ account }}] unattached EBS volumes snapshotted and deleted in {{ region }}'

--- a/example_config_multi_repo/policies/team/one-account/us-east-2/ec2-low-utilization-mark.yml
+++ b/example_config_multi_repo/policies/team/one-account/us-east-2/ec2-low-utilization-mark.yml
@@ -1,0 +1,46 @@
+# REMINDER: defaults.yml will be merged in to this. See the README.
+name: ec2-low-utilization-mark
+comment: EC2 Instances with low utilization - notify via email and mark to terminate in 14 days. Look at 2 days worth of data.
+resource: ec2
+filters:
+  # not tagged for this policy; otherwise, we'd just keep pushing the mark date forward
+  - {'tag:c7n-ec2-low-utilization': absent}
+  # instance is running
+  - {State.Name: running}
+  # Instance Type isn't t2.nano or t2.micro
+  - type: value
+    key: "InstanceType"
+    op: not-in
+    value:
+      - "t2.nano"
+      - "t2.micro"
+  # CPUUtilization 15-minute average < 4% over the last day
+  - type: metrics
+    name: CPUUtilization
+    days: 1
+    period: 900
+    statistics: Average
+    value: 4
+    op: less-than
+  # NetworkIn less than 7k per 6-hours over the last day
+  - type: metrics
+    name: NetworkIn
+    days: 1
+    period: 21600
+    statistics: Maximum
+    value: 7000
+    op: less-than
+  # NetworkOut less than 7k per 6-hours over the last day
+  - type: metrics
+    name: NetworkOut
+    days: 1
+    period: 21600
+    statistics: Maximum
+    value: 7000
+    op: less-than
+actions:
+  - type: mark-for-op
+    tag: c7n-ec2-low-utilization
+    msg: "ec2-low-utilization-mark: {op}@{action_date}"
+    op: terminate
+    days: 14

--- a/example_config_multi_repo/policies/team/one-account/us-west-2/ec2-low-utilization-mark.yml
+++ b/example_config_multi_repo/policies/team/one-account/us-west-2/ec2-low-utilization-mark.yml
@@ -1,0 +1,46 @@
+# REMINDER: defaults.yml will be merged in to this. See the README.
+name: ec2-low-utilization-mark
+comment: EC2 Instances with low utilization - notify via email and mark to terminate in 14 days. Look at 2 days worth of data.
+resource: ec2
+filters:
+  # not tagged for this policy; otherwise, we'd just keep pushing the mark date forward
+  - {'tag:c7n-ec2-low-utilization': absent}
+  # instance is running
+  - {State.Name: running}
+  # Instance Type isn't t2.nano or t2.micro
+  - type: value
+    key: "InstanceType"
+    op: not-in
+    value:
+      - "t2.nano"
+      - "t2.micro"
+  # CPUUtilization 15-minute average < 4% over the last day
+  - type: metrics
+    name: CPUUtilization
+    days: 1
+    period: 900
+    statistics: Average
+    value: 4
+    op: less-than
+  # NetworkIn less than 7k per 6-hours over the last day
+  - type: metrics
+    name: NetworkIn
+    days: 1
+    period: 21600
+    statistics: Maximum
+    value: 7000
+    op: less-than
+  # NetworkOut less than 7k per 6-hours over the last day
+  - type: metrics
+    name: NetworkOut
+    days: 1
+    period: 21600
+    statistics: Maximum
+    value: 7000
+    op: less-than
+actions:
+  - type: mark-for-op
+    tag: c7n-ec2-low-utilization
+    msg: "ec2-low-utilization-mark: {op}@{action_date}"
+    op: terminate
+    days: 14

--- a/manheim_c7n_tools/config.py
+++ b/manheim_c7n_tools/config.py
@@ -54,6 +54,9 @@ MANHEIM_CONFIG_SCHEMA = {
                 'duration_seconds': {'type': 'number'}
             }
         },
+        # Optional policy source paths. If not specified, uses the current
+        # directory
+        'policy_source_paths': {'type': 'array', 'items': {'type': 'string'}},
         # A list of region names that custodian should run in for this account
         'regions': {'type': 'array', 'items': {'type': 'string'}},
         # Name of the S3 bucket for storing Custodian output; should include

--- a/manheim_c7n_tools/policygen.py
+++ b/manheim_c7n_tools/policygen.py
@@ -33,7 +33,7 @@ from manheim_c7n_tools.version import VERSION, PROJECT_URL
 from manheim_c7n_tools.config import ManheimConfig
 from manheim_c7n_tools.utils import git_html_url
 
-whtspc_re = re.compile('\s+')
+whtspc_re = re.compile(r'\s+')
 
 logger = logging.getLogger(__name__)
 
@@ -68,26 +68,11 @@ class PolicyGen(object):
         )
 
     def run(self):
-        # read the global defaults
-        defaults = self._read_file_yaml(
-            os.path.join('policies', 'defaults.yml')
-        )
-        # read the shared configs from all_accounts/ ; returns a dict of
-        # region name to [dict of policy name to policy], for each region
-        all_accts = self._read_policy_directory('all_accounts')
-        # dict to hold account_name -> config for that account
-        acct_configs = {}
-        # loop over all accounts in the config file
-        for acctname in self._config.list_accounts(self._config.config_path):
-            # start with the all_accts dict, for common config
-            conf = deepcopy(all_accts)
-            # read the account's config
-            acct_conf = self._read_policy_directory(acctname)
-            # for each region, layer per-account over all_accounts
-            for rname in self._config.regions:
-                conf[rname].update(acct_conf[rname])
-            # store result
-            acct_configs[acctname] = conf
+        defaults = self._load_defaults()
+        if defaults is None:
+            logger.error('Failed to find a `defaults.yml` file')
+            raise SystemExit(1)
+        acct_configs = self._read_policies()
         # generate the per-region configs for each region, for current account
         for rname in self._config.regions:
             self._generate_configs(
@@ -99,6 +84,72 @@ class PolicyGen(object):
         self._write_file('policies.rst', self._policy_rst(acct_configs))
         logger.info('Writing region list to regions.rst...')
         self._write_file('regions.rst', self._regions_rst())
+
+    def _load_defaults(self):
+        """
+        Load a defaults.yml file from either the ``policies/`` subdirectory
+        or directories in the ``policy_source_paths`` configuration key.
+        """
+        defaults = None
+        # read the global defaults
+        if os.path.exists(os.path.join('policies', 'defaults.yml')):
+            defaults = self._read_file_yaml(
+                os.path.join('policies', 'defaults.yml')
+            )
+
+        # check policy folders for defaults
+        if 'policy_source_paths' in self._config:
+            for path in self._config.policy_source_paths:
+                if os.path.exists(os.path.join('policies', path, 'defaults.yml')):
+                    defaults = self._read_file_yaml(
+                        os.path.join('policies', path, 'defaults.yml')
+                    )
+        return defaults
+
+    def _read_policies(self):
+        """
+        Read the policies, either the current list of ``policy_source_paths``
+        directories if the config key exists, or simply the ``policies/``
+        subdirectory if it doesn't.
+        """
+        # dict to hold account_name -> config for that account
+        acct_configs = {}
+        # SOOO much redundancy
+        if 'policy_source_paths' in self._config:
+            # TODO: Loop over all source paths, meging them together in order
+            for path in self._config.policy_source_paths:
+                policy_path_configs = {}
+                # read the shared configs from all_accounts/ ; returns a dict of
+                # region name to [dict of policy name to policy], for each region
+                all_accts = self._read_policy_directory('all_accounts')
+                # loop over all accounts in the config file
+                for acctname in self._config.list_accounts(self._config.config_path):
+                    # start with the all_accts dict, for common config
+                    conf = deepcopy(all_accts)
+                    # read the account's config
+                    acct_conf = self._read_policy_directory(os.path.join(path, acctname))
+                    # for each region, layer per-account over all_accounts
+                    for rname in self._config.regions:
+                        conf[rname].update(acct_conf[rname])
+                    # store result
+                    policy_path_configs[acctname] = conf
+                acct_configs = deepcopy(policy_path_configs)
+        else:
+            # read the shared configs from all_accounts/ ; returns a dict of
+            # region name to [dict of policy name to policy], for each region
+            all_accts = self._read_policy_directory('all_accounts')
+            # loop over all accounts in the config file
+            for acctname in self._config.list_accounts(self._config.config_path):
+                # start with the all_accts dict, for common config
+                conf = deepcopy(all_accts)
+                # read the account's config
+                acct_conf = self._read_policy_directory(acctname)
+                # for each region, layer per-account over all_accounts
+                for rname in self._config.regions:
+                    conf[rname].update(acct_conf[rname])
+                # store result
+                acct_configs[acctname] = conf
+        return acct_configs
 
     def _read_policy_directory(self, policy_dir):
         """
@@ -144,7 +195,7 @@ class PolicyGen(object):
             )
         if self._config.cleanup_notify:
             logger.info('Generating c7n cleanup policies...')
-            # add c7n lambda/CW Even cleanup policies
+            # add c7n lambda/CW Event cleanup policies
             for pol in self._generate_cleanup_policies(
                 deepcopy(result['policies'])
             ):

--- a/manheim_c7n_tools/policygen.py
+++ b/manheim_c7n_tools/policygen.py
@@ -120,9 +120,11 @@ class PolicyGen(object):
         # dict to hold account_name -> config for that account
         acct_configs = {}
         try:
-            paths = self._config.policy_source_paths
-            logger.info("Reading from multiple source paths: %s", paths)
-            for path in paths:
+            logger.info(
+                "Reading from multiple source paths: %s",
+                self._config.policy_source_paths
+            )
+            for path in self._config.policy_source_paths:
                 logger.info("Reading configs from %s", path)
                 configs = self._load_policy(path=path)
                 acct_configs = self._merge_configs(acct_configs, configs)

--- a/manheim_c7n_tools/policygen.py
+++ b/manheim_c7n_tools/policygen.py
@@ -144,7 +144,9 @@ class PolicyGen(object):
         acct_configs = {}
         # read the shared configs from all_accounts/ ; returns a dict of
         # region name to [dict of policy name to policy], for each region
-        all_accts = self._read_policy_directory('all_accounts')
+        all_accts = self._read_policy_directory(
+            os.path.join(path, 'all_accounts')
+        )
         # loop over all accounts in the config file
         for acctname in self._config.list_accounts(self._config.config_path):
             # start with the all_accts dict, for common config

--- a/manheim_c7n_tools/policygen.py
+++ b/manheim_c7n_tools/policygen.py
@@ -145,11 +145,14 @@ class PolicyGen(object):
                     if region in new_config[acctname]:
                         for rule in source[acctname][region]:
                             if rule in new_config[acctname][region]:
-                                new_config[acctname][region][rule].update(source[acctname][region][rule])
+                                new_config[acctname][region][rule] \
+                                    .update(source[acctname][region][rule])
                             else:
-                                new_config[acctname][region][rule] = deepcopy(source[acctname][region][rule])
+                                new_config[acctname][region][rule] = \
+                                    deepcopy(source[acctname][region][rule])
                     else:
-                        new_config[acctname][region] = deepcopy(source[acctname][region])
+                        new_config[acctname][region] = \
+                            deepcopy(source[acctname][region])
             else:
                 new_config[acctname] = deepcopy(source[acctname])
         return new_config

--- a/manheim_c7n_tools/tests/test_policygen.py
+++ b/manheim_c7n_tools/tests/test_policygen.py
@@ -1089,6 +1089,135 @@ class TestLoadDefaults(PolicyGenTester):
             assert d == 'default2'
 
 
+class TestMergeConfigs(PolicyGenTester):
+    def test_new_account(self):
+        source = {
+            'myAccount': {
+                'region1': {
+                    'rule1': {
+                        'foo': 'bar-myAccount/region1'
+                    },
+                    'rule2': {
+                        'baz': 'blam'
+                    }
+                }
+            },
+            'otherAccount': {
+                'region1': {
+                    'rule1': {
+                        'foo': 'bar-myAccount/region1'
+                    },
+                    'rule2': {
+                        'baz': 'blam'
+                    }
+                }
+            }
+        }
+
+        target = {
+            'otherAccount': {
+                'region1': {
+                    'rule1': {
+                        'foo': 'bar-myAccount/region1'
+                    },
+                    'rule2': {
+                        'baz': 'blam'
+                    }
+                }
+            }
+        }
+
+        res = self.cls._merge_configs(target, source)
+        assert res['myAccount'] is not None
+        assert res['otherAccount'] is not None
+
+    def test_new_region(self):
+        source = {
+            'otherAccount': {
+                'region1': {
+                    'rule1': {
+                        'foo': 'bar-myAccount/region1'
+                    },
+                    'rule2': {
+                        'baz': 'blam'
+                    }
+                }
+            }
+        }
+
+        target = {
+            'otherAccount': {
+                'region2': {
+                    'rule1': {
+                        'foo': 'bar-myAccount/region2'
+                    },
+                    'rule2': {
+                        'baz': 'blam'
+                    }
+                }
+            }
+        }
+
+        res = self.cls._merge_configs(target, source)
+        assert res['otherAccount']['region1'] is not None
+        assert res['otherAccount']['region2'] is not None
+
+    def test_new_rule(self):
+        source = {
+            'otherAccount': {
+                'region1': {
+                    'rule2': {
+                        'baz': 'blam'
+                    }
+                }
+            }
+        }
+
+        target = {
+            'otherAccount': {
+                'region1': {
+                    'rule1': {
+                        'foo': 'bar-myAccount/region2'
+                    }
+                }
+            }
+        }
+
+        res = self.cls._merge_configs(target, source)
+        assert res['otherAccount']['region1']['rule1'] is not None
+        assert res['otherAccount']['region1']['rule2'] is not None
+
+    def test_rule_overrides(self):
+        source = {
+            'myAccount': {
+                'region1': {
+                    'rule1': {
+                        'foo': 'bar-myAccount/region1'
+                    },
+                    'rule2': {
+                        'baz': 'blam'
+                    }
+                }
+            }
+        }
+
+        target = {
+            'myAccount': {
+                'region1': {
+                    'rule1': {
+                        'foo': 'bar-myAccount/region1'
+                    },
+                    'rule2': {
+                        'baz': 'bang'
+                    }
+                }
+            }
+        }
+
+        res = self.cls._merge_configs(target, source)
+        assert res['myAccount']['region1']['rule2']['baz'] == 'blam'
+
+
 class TestLoadAllPolicies(PolicyGenTester):
     def test_no_source_paths(self):
         with patch(

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,7 @@ with open('README.md') as f:
 
 requires = [
     'boto3',
+    'docutils>=0.10,<0.15',
     'tabulate>=0.8.0,<0.9.0',
     # In order to work with the "mu" Lambda function management tool,
     # we need PyYAML 3.x, and need it as source and not a wheel


### PR DESCRIPTION
## Description

Updates to policygen to allow aggregating multiple policy directories via a new
configuration entry. A new configuration value was added,
`policy_source_paths`, which are assumed to be relative to the `policies`
subdirectory. They are processed in the order listed in the configuration file,
with rules of the same name in later paths taking precedence over those in
earlier paths.

Defaults are treated in a similar way, with a `defaults.yml` in a later path
overriding those in an earlier path. If none of the source paths have
a `defaults.yml`, it will be taken from the `policies` directory.

## Testing Done

Local testing was performed on a new rules repo with multiple configurations,
examinging the output to confirm that rules were generated properly.

## Important Notes

A test repo is being configured for use in verification of this submission.

## Contributor License Agreement

Required for external contributors.

By submitting this work for inclusion in manheim-c7n-tools, I agree to the following terms:

* The contribution included in this request (and any subsequent revisions or versions of it)
  is being made under the same license as the manheim-c7n-tools project (Apache v2).
* My contribution may perpetually be included in and distributed with manheim-c7n-tools; submitting
  this pull request grants a perpetual, global, unlimited license for it to be used and distributed
  under the terms of manheim-c7n-tools's license.
* I have the legal power and rights to agree to these terms.