### PR TITLE
Uncomment doc link to multi repo example

### DIFF
--- a/docs/source/policies.rst
+++ b/docs/source/policies.rst
@@ -98,7 +98,7 @@ Multiple Repository Layout
             └── us-west-2
                 └── policy-four-us-west-2.yml
 
-.. An example configuration for a multiple repository setup can be seen at `https://github.com/manheim/manheim-c7n-tools/tree/master/example_config_multi_repo <https://github.com/manheim/manheim-c7n-tools/tree/master/example_config_multi_repo>`_.
+An example configuration for a multiple repository setup can be seen at `https://github.com/manheim/manheim-c7n-tools/tree/master/example_config_multi_repo <https://github.com/manheim/manheim-c7n-tools/tree/master/example_config_multi_repo>`_.
 
 .. _`policies.region_interpolation`:
 


### PR DESCRIPTION
## Description

A link to an example of a multi-repo layout was commented out in a previous PR
(#12), as that PR was going to create the link target. This PR re-establishes
the link now that the previous PR is mergedp.

## Testing Done

Local docs build

## Contributor License Agreement

Required for external contributors.

By submitting this work for inclusion in manheim-c7n-tools, I agree to the following terms:

* The contribution included in this request (and any subsequent revisions or versions of it)
  is being made under the same license as the manheim-c7n-tools project (Apache v2).
* My contribution may perpetually be included in and distributed with manheim-c7n-tools; submitting
  this pull request grants a perpetual, global, unlimited license for it to be used and distributed
  under the terms of manheim-c7n-tools's license.
* I have the legal power and rights to agree to these terms.