### PR TITLE
Bumps c7n to latest release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,9 +27,6 @@ stages:
 jobs:
   include:
     - stage: test
-      python: '2.7'
-      env: TOXENV=py27
-    - stage: test
       python: '3.6'
       env: TOXENV=py36
     - stage: test

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+0.8.2 (2020-03-20)
+------------------
+
+* Bump c7n to release 0.8.46.0
+* Bump c7n-mailer release to 0.5.7
+* Pin mock package to 3.0.5
+* Remove python2
+
 0.8.1 (2019-11-08)
 ------------------
 

--- a/manheim_c7n_tools/version.py
+++ b/manheim_c7n_tools/version.py
@@ -17,7 +17,7 @@ manheim-c7n-tools version configuration.
 """
 
 #: The semver-compliant version of the package.
-VERSION = '0.8.1'
+VERSION = '0.8.2'
 
 #: The URL for further information about the package.
 PROJECT_URL = 'https://github.com/manheim/manheim-c7n-tools'

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ requires = [
     # In order to work with the "mu" Lambda function management tool,
     # we need PyYAML 3.x, and need it as source and not a wheel
     'pyyaml',
-    'c7n==0.8.45.2',
-    'c7n-mailer==0.5.6',
+    'c7n==0.8.46.0',
+    'c7n-mailer==0.5.7',
     # for building generated policy docs
     'sphinx>=1.8.0,<1.9.0',
     'sphinx_rtd_theme'

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36,py37,docs,docker
+envlist = py36,py37,docs,docker
 
 [testenv]
 deps =
@@ -15,7 +15,7 @@ deps =
   pytest-pep8
   pytest-flakes
   pytest-html
-  mock
+  mock==3.0.5
   freezegun
   pytest-blockage
 


### PR DESCRIPTION
## Description

Bumps c7n to the latest release version. Drops support for testing with python2. Fixes tests due to mock package incompatibilities with version 4.x.

## Testing Done

https://travis-ci.org/github/manheim/manheim-c7n-tools/builds/664895816

## Important Notes

_Optional; instructions to reviewers, plans for how to release this, dependencies in other repos, etc._

## Contributor License Agreement

Required for external contributors.

By submitting this work for inclusion in manheim-c7n-tools, I agree to the following terms:

* The contribution included in this request (and any subsequent revisions or versions of it)
  is being made under the same license as the manheim-c7n-tools project (Apache v2).
* My contribution may perpetually be included in and distributed with manheim-c7n-tools; submitting
  this pull request grants a perpetual, global, unlimited license for it to be used and distributed
  under the terms of manheim-c7n-tools's license.
* I have the legal power and rights to agree to these terms.
