### PR TITLE
0.8.4 - warn on missing dead letter queue instead of dying

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.8.4 (2020-04-01)
+------------------
+
+* ``errorscan`` - Warn on missing SQS dead letter queue instead of failing, to support deployments that only run mailer in one region.
+
 0.8.3 (2020-03-26)
 ------------------
 

--- a/manheim_c7n_tools/version.py
+++ b/manheim_c7n_tools/version.py
@@ -17,7 +17,7 @@ manheim-c7n-tools version configuration.
 """
 
 #: The semver-compliant version of the package.
-VERSION = '0.8.3'
+VERSION = '0.8.4'
 
 #: The URL for further information about the package.
 PROJECT_URL = 'https://github.com/manheim/manheim-c7n-tools'


### PR DESCRIPTION
## Description

Right now, the ``errorscan`` script expects the dead letter SQS queue (for c7n-mailer) to exist in whatever region errorscan is running in. This results in an unhandled exception for environments where c7n-mailer is only deployed into one region. This PR changes it to log a warning, but continue, if the SQS queue can't be found.

## Testing Done

In an account where c7n-mailer and its SQS queues are only deployed into us-east-1:

on master, running errorscan in us-east-2:

```
$ errorscan -v -A -c ~/tmp/manheim-c7n-tools.yml myacct us-east-2
2020-04-01 12:00:13,673 INFO:manheim_c7n_tools.config:Loading config from: /home/jantman/tmp/manheim-c7n-tools.yml
Traceback (most recent call last):
  File "/home/jantman/manheim/git/github_dot_com/manheim-c7n-tools/venv/bin/errorscan", line 11, in <module>
    load_entry_point('manheim-c7n-tools', 'console_scripts', 'errorscan')()
  File "/home/jantman/manheim/git/github_dot_com/manheim-c7n-tools/manheim_c7n_tools/errorscan.py", line 623, in main
    CustodianErrorReporter(conf, args.REGION_NAME).run()
  File "/home/jantman/manheim/git/github_dot_com/manheim-c7n-tools/manheim_c7n_tools/errorscan.py", line 379, in __init__
    self._dlq_url = self._sqs_arn_to_url(
  File "/home/jantman/manheim/git/github_dot_com/manheim-c7n-tools/manheim_c7n_tools/errorscan.py", line 404, in _sqs_arn_to_url
    url = self._sqs.get_queue_url(
  File "/home/jantman/manheim/git/github_dot_com/manheim-c7n-tools/venv/lib/python3.8/site-packages/botocore-1.15.33-py3.8.egg/botocore/client.py", line 316, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/home/jantman/manheim/git/github_dot_com/manheim-c7n-tools/venv/lib/python3.8/site-packages/botocore-1.15.33-py3.8.egg/botocore/client.py", line 626, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.errorfactory.QueueDoesNotExist: An error occurred (AWS.SimpleQueueService.NonExistentQueue) when calling the GetQueueUrl operation: The specified queue does not exist for this wsdl version.
```

same run, but on this branch:

```
$ errorscan -v -A -c ~/tmp/manheim-c7n-tools.yml myacct us-east-2
2020-04-01 12:01:04,414 INFO:manheim_c7n_tools.config:Loading config from: /home/jantman/tmp/manheim-c7n-tools.yml
2020-04-01 12:01:04,685 INFO:root:SQS Queue arn:aws:sqs:us-east-2:012345678901:cloud-custodian-012345678901-deadletter does not exist
Searching cloud-custodian Lambda functions for failed invocations
2020-04-01 12:01:04,949 WARNING:root:Dead-letter SQS queue could not be found; skipping
custodian-ami-old-used-report: OK

custodian-asg-inactive-delete: OK
...
```