### PR TITLE
Issue fixes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,8 @@
 Changelog
 =========
 
-Unreleased
-----------
+0.8.5 (2020-04-06)
+------------------
 
 * Update ``policygen`` to also handle layering of ``mailer-templates`` directory contents from ``policy_source_paths`` into ``./mailer-templates``.
 * Fixes `#23 <https://github.com/manheim/manheim-c7n-tools/issues/23>`_ - Document ``cleanup_notify`` config parameter in example ``manheim-c7n-tools.yml`` files and default it to an empty list.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Unreleased
 ----------
 
 * Update ``policygen`` to also handle layering of ``mailer-templates`` directory contents from ``policy_source_paths`` into ``./mailer-templates``.
+* Document ``cleanup_notify`` config parameter in example ``manheim-c7n-tools.yml`` files and default it to an empty list.
 
 0.8.4 (2020-04-01)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,8 @@ Unreleased
 ----------
 
 * Update ``policygen`` to also handle layering of ``mailer-templates`` directory contents from ``policy_source_paths`` into ``./mailer-templates``.
-* Document ``cleanup_notify`` config parameter in example ``manheim-c7n-tools.yml`` files and default it to an empty list.
+* Fixes `#23 <https://github.com/manheim/manheim-c7n-tools/issues/23>`_ - Document ``cleanup_notify`` config parameter in example ``manheim-c7n-tools.yml`` files and default it to an empty list.
+* Fixes `#24 <https://github.com/manheim/manheim-c7n-tools/issues/24>`_ - Remove requirement that us-east-1 must be first configured region, or configured at all.
 
 0.8.4 (2020-04-01)
 ------------------

--- a/example_config_multi_repo/manheim-c7n-tools.yml
+++ b/example_config_multi_repo/manheim-c7n-tools.yml
@@ -10,10 +10,23 @@
     - us-east-2
     - us-west-1
     - us-west-2
+  # List of policy directories (generally, git repo clones) to layer together
+  # to build final policies. Later items in the list override earlier ones; see
+  # documentation for further information.
   policy_source_paths:
     - shared
     - team
     - app
+  # List of email addresses to notify for orphaned resources. If this list is
+  # non-empty, then policygen will inject two daily-run policies that identify
+  # cloud-custodian Lambdas and CloudWatch Event Rules that don't match the
+  # configured policies (i.e. left behind by manual testing or deleted policies)
+  # and send a notification about them to the listed c7n-mailer targets.
+  # IMPORTANT: Some aspects of the tags expected by this feature may be
+  # overly Manheim-specific.
+  # Defaults to an empty list, which disables this feature.
+  cleanup_notify:
+    - us@example.com
   # Name of c7n output S3 bucket
   output_s3_bucket_name: c7n-123456789012-%%AWS_REGION%%
   # Name of c7n CloudWatch Log Group

--- a/example_config_repo/manheim-c7n-tools.yml
+++ b/example_config_repo/manheim-c7n-tools.yml
@@ -10,6 +10,16 @@
     - us-east-2
     - us-west-1
     - us-west-2
+  # List of email addresses to notify for orphaned resources. If this list is
+  # non-empty, then policygen will inject two daily-run policies that identify
+  # cloud-custodian Lambdas and CloudWatch Event Rules that don't match the
+  # configured policies (i.e. left behind by manual testing or deleted policies)
+  # and send a notification about them to the listed c7n-mailer targets.
+  # IMPORTANT: Some aspects of the tags expected by this feature may be
+  # overly Manheim-specific.
+  # Defaults to an empty list, which disables this feature.
+  cleanup_notify:
+    - us@example.com
   # Name of c7n output S3 bucket
   output_s3_bucket_name: c7n-123456789012-%%AWS_REGION%%
   # Name of c7n CloudWatch Log Group

--- a/manheim_c7n_tools/config.py
+++ b/manheim_c7n_tools/config.py
@@ -35,8 +35,7 @@ MANHEIM_CONFIG_SCHEMA = {
         'output_s3_bucket_name',
         'custodian_log_group',
         'dead_letter_queue_arn',
-        'role_arn',
-        'cleanup_notify'
+        'role_arn'
     ],
     'properties': {
         # The AWS Account ID
@@ -123,6 +122,8 @@ class ManheimConfig(object):
             )
         self._config = kwargs
         self._config['account_id'] = str(self._config['account_id'])
+        if 'cleanup_notify' not in self._config:
+            self._config['cleanup_notify'] = []
 
     @staticmethod
     def from_file(path, account_name):

--- a/manheim_c7n_tools/config.py
+++ b/manheim_c7n_tools/config.py
@@ -116,10 +116,6 @@ class ManheimConfig(object):
         self.config_path = kwargs.pop('config_path')
         logger.debug('Validating configuration...')
         jsonschema.validate(kwargs, MANHEIM_CONFIG_SCHEMA)
-        if kwargs['regions'][0] != 'us-east-1':
-            raise RuntimeError(
-                'ERROR: the first configured region must be us-east-1'
-            )
         self._config = kwargs
         self._config['account_id'] = str(self._config['account_id'])
         if 'cleanup_notify' not in self._config:

--- a/manheim_c7n_tools/runner.py
+++ b/manheim_c7n_tools/runner.py
@@ -140,8 +140,9 @@ class PolicygenStep(BaseStep):
         self._do_policygen()
 
     @staticmethod
-    def run_in_region(region_name, _):
-        return region_name == 'us-east-1'
+    def run_in_region(region_name, conf):
+        # only run in the first-configured region
+        return region_name == conf.regions[0]
 
 
 class ValidateStep(BaseStep):
@@ -378,8 +379,9 @@ class DocsBuildStep(BaseStep):
         self._run_sphinx_build()
 
     @staticmethod
-    def run_in_region(region_name, _):
-        return region_name == 'us-east-1'
+    def run_in_region(region_name, conf):
+        # only run in the first-configured region
+        return region_name == conf.regions[0]
 
 
 class CustodianRunner(object):

--- a/manheim_c7n_tools/tests/test_config.py
+++ b/manheim_c7n_tools/tests/test_config.py
@@ -30,11 +30,12 @@ class TestManheimConfig(object):
             ) as mock_validate:
                 cls = ManheimConfig(
                     foo='bar', baz=2, regions=['us-east-1'],
-                    config_path='manheim-c7n-tools.yml', account_id='1234'
+                    config_path='manheim-c7n-tools.yml', account_id='1234',
+                    cleanup_notify=['foo@bar.com']
                 )
         assert cls._config == {
             'foo': 'bar', 'baz': 2, 'regions': ['us-east-1'],
-            'account_id': '1234'
+            'account_id': '1234', 'cleanup_notify': ['foo@bar.com']
         }
         assert cls.config_path == 'manheim-c7n-tools.yml'
         assert mock_logger.mock_calls == [
@@ -44,7 +45,7 @@ class TestManheimConfig(object):
             call(
                 {
                     'foo': 'bar', 'baz': 2, 'regions': ['us-east-1'],
-                    'account_id': '1234'
+                    'account_id': '1234', 'cleanup_notify': ['foo@bar.com']
                 },
                 MANHEIM_CONFIG_SCHEMA
             )
@@ -255,7 +256,8 @@ class TestManheimConfig(object):
                 }
             },
             'account_id': '012345',
-            'regions': ['us-east-1', 'us-east-2']
+            'regions': ['us-east-1', 'us-east-2'],
+            'cleanup_notify': []
         }
         with patch('%s.jsonschema.validate' % pbm, autospec=True):
             with patch.dict(

--- a/manheim_c7n_tools/tests/test_config.py
+++ b/manheim_c7n_tools/tests/test_config.py
@@ -56,13 +56,16 @@ class TestManheimConfig(object):
             with patch(
                 '%s.jsonschema.validate' % pbm, autospec=True
             ) as mock_validate:
-                with pytest.raises(RuntimeError) as exc:
-                    ManheimConfig(
-                        foo='bar', baz=2, regions=['us-east-2'],
-                        config_path='manheim-c7n-tools.yml', account_id=1234
-                    )
-        assert str(exc.value) == 'ERROR: the first configured region must be ' \
-                                 'us-east-1'
+                cls = ManheimConfig(
+                    foo='bar', baz=2, regions=['us-east-2'],
+                    config_path='manheim-c7n-tools.yml', account_id='1234',
+                    cleanup_notify=['foo@bar.com']
+                )
+        assert cls._config == {
+            'foo': 'bar', 'baz': 2, 'regions': ['us-east-2'],
+            'account_id': '1234', 'cleanup_notify': ['foo@bar.com']
+        }
+        assert cls.config_path == 'manheim-c7n-tools.yml'
         assert mock_logger.mock_calls == [
             call.debug('Validating configuration...')
         ]
@@ -70,7 +73,7 @@ class TestManheimConfig(object):
             call(
                 {
                     'foo': 'bar', 'baz': 2, 'regions': ['us-east-2'],
-                    'account_id': 1234
+                    'account_id': '1234', 'cleanup_notify': ['foo@bar.com']
                 },
                 MANHEIM_CONFIG_SCHEMA
             )

--- a/manheim_c7n_tools/tests/test_runner.py
+++ b/manheim_c7n_tools/tests/test_runner.py
@@ -47,6 +47,12 @@ ALL_REGIONS = [
 ]
 
 
+class FakeConfig:
+
+    def __init__(self, regions):
+        self.regions = regions
+
+
 class StepTester(object):
 
     def setup(self):
@@ -72,11 +78,12 @@ class TestPolicygenStep(StepTester):
         ]
 
     def test_run_in_region(self):
+        conf = FakeConfig(ALL_REGIONS)
         for rname in ALL_REGIONS:
-            if rname == 'us-east-1':
-                assert runner.PolicygenStep.run_in_region(rname, None) is True
+            if rname == ALL_REGIONS[0]:
+                assert runner.PolicygenStep.run_in_region(rname, conf) is True
             else:
-                assert runner.PolicygenStep.run_in_region(rname, None) is False
+                assert runner.PolicygenStep.run_in_region(rname, conf) is False
 
 
 class TestValidateStep(StepTester):
@@ -505,11 +512,12 @@ class TestDocsBuildStep(StepTester):
         ]
 
     def test_run_in_region(self):
+        conf = FakeConfig(ALL_REGIONS)
         for rname in ALL_REGIONS:
-            if rname == 'us-east-1':
-                assert runner.DocsBuildStep.run_in_region(rname, None) is True
+            if rname == ALL_REGIONS[0]:
+                assert runner.DocsBuildStep.run_in_region(rname, conf) is True
             else:
-                assert runner.DocsBuildStep.run_in_region(rname, None) is False
+                assert runner.DocsBuildStep.run_in_region(rname, conf) is False
 
 
 class TestStepClasses(object):

--- a/manheim_c7n_tools/version.py
+++ b/manheim_c7n_tools/version.py
@@ -17,7 +17,7 @@ manheim-c7n-tools version configuration.
 """
 
 #: The semver-compliant version of the package.
-VERSION = '0.8.4'
+VERSION = '0.8.5'
 
 #: The URL for further information about the package.
 PROJECT_URL = 'https://github.com/manheim/manheim-c7n-tools'


### PR DESCRIPTION
## Description

This PR rolls up fixes for two issues:

* #23 - the ``cleanup_notify`` config parameter was required but undocumented. This PR documents it, and also makes it optional with a default of an empty list.
* #24 - we previously _required_ the ``us-east-1`` region to be configured and run first out of all regions. The only reason I could find for this (aside from it's where we happen to run mailer, but that's just a convention of ours internally) is we used it to ensure that we only run the Policygen and Docs Generation steps once, in the first region. However, we could instead just run them in the first-configured region (first ``config.regions`` list item). That's what this PR does.

## Testing Done

Unit tests.