### PR TITLE
Fix bug in 0.8.5 - mailer template loading logic was missing policies directory prefix

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.8.6 (2020-04-07)
+------------------
+
+* Fix bug in 0.8.5 - mailer template loading logic was missing ``policies/`` directory prefix.
+
 0.8.5 (2020-04-06)
 ------------------
 

--- a/manheim_c7n_tools/policygen.py
+++ b/manheim_c7n_tools/policygen.py
@@ -779,7 +779,7 @@ class PolicyGen(object):
                 self._config.policy_source_paths
             )
             for path in self._config.policy_source_paths:
-                mailerdir = os.path.join(path, 'mailer-templates')
+                mailerdir = os.path.join('policies', path, 'mailer-templates')
                 if not os.path.exists(mailerdir):
                     logger.debug('%s does not exist; skipping', mailerdir)
                     continue

--- a/manheim_c7n_tools/tests/test_policygen.py
+++ b/manheim_c7n_tools/tests/test_policygen.py
@@ -2661,20 +2661,20 @@ class TestMailerTemplatePaths(PolicyGenTester):
         )
 
         def se_ope(path):
-            if path == 'two/mailer-templates':
+            if path == 'policies/two/mailer-templates':
                 return False
             return True
 
         def se_isfile(path):
             if path in [
-                'one/mailer-templates/notfile.tpl',
-                'three/mailer-templates/no.tpl'
+                'policies/one/mailer-templates/notfile.tpl',
+                'policies/three/mailer-templates/no.tpl'
             ]:
                 return False
             return True
 
         def se_listdir(path):
-            if path == 'one/mailer-templates':
+            if path == 'policies/one/mailer-templates':
                 return ['foo.tpl', 'bar.tpl', 'notfile.tpl']
             return ['foo.tpl', 'baz.tpl', 'no.tpl']
 
@@ -2686,26 +2686,26 @@ class TestMailerTemplatePaths(PolicyGenTester):
                     m_isfile.side_effect = se_isfile
                     res = self.cls._mailer_template_paths()
         assert res == {
-            'foo.tpl': 'three/mailer-templates/foo.tpl',
-            'bar.tpl': 'one/mailer-templates/bar.tpl',
-            'baz.tpl': 'three/mailer-templates/baz.tpl'
+            'foo.tpl': 'policies/three/mailer-templates/foo.tpl',
+            'bar.tpl': 'policies/one/mailer-templates/bar.tpl',
+            'baz.tpl': 'policies/three/mailer-templates/baz.tpl'
         }
         assert m_ope.mock_calls == [
-            call('one/mailer-templates'),
-            call('two/mailer-templates'),
-            call('three/mailer-templates')
+            call('policies/one/mailer-templates'),
+            call('policies/two/mailer-templates'),
+            call('policies/three/mailer-templates')
         ]
         assert m_listdir.mock_calls == [
-            call('one/mailer-templates'),
-            call('three/mailer-templates')
+            call('policies/one/mailer-templates'),
+            call('policies/three/mailer-templates')
         ]
         assert m_isfile.mock_calls == [
-            call('one/mailer-templates/foo.tpl'),
-            call('one/mailer-templates/bar.tpl'),
-            call('one/mailer-templates/notfile.tpl'),
-            call('three/mailer-templates/foo.tpl'),
-            call('three/mailer-templates/baz.tpl'),
-            call('three/mailer-templates/no.tpl'),
+            call('policies/one/mailer-templates/foo.tpl'),
+            call('policies/one/mailer-templates/bar.tpl'),
+            call('policies/one/mailer-templates/notfile.tpl'),
+            call('policies/three/mailer-templates/foo.tpl'),
+            call('policies/three/mailer-templates/baz.tpl'),
+            call('policies/three/mailer-templates/no.tpl'),
         ]
 
     def test_no_policy_source_paths(self):

--- a/manheim_c7n_tools/version.py
+++ b/manheim_c7n_tools/version.py
@@ -17,7 +17,7 @@ manheim-c7n-tools version configuration.
 """
 
 #: The semver-compliant version of the package.
-VERSION = '0.8.5'
+VERSION = '0.8.6'
 
 #: The URL for further information about the package.
 PROJECT_URL = 'https://github.com/manheim/manheim-c7n-tools'


### PR DESCRIPTION
## Description

The previous release has a critical bug where mailer-templates are looked for in ``<additional_source_repo>/mailer-templates`` instead of ``policies/<additional_source_repo>/mailer-templates``, and therefore never found.

## Testing Done

Unit tests and local manual testing.