### PR TITLE
Templates folders

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+0.8.7 (2020-04-08)
+------------------
+
+* Previously, manheim-c7n-tools set c7n-mailer's ``templates_folders`` configuration option to ``/manheim_c7n_tools/manheim_c7n_tools/mailer-templates`` if that directory exists, or to the absolute path to a ``mailer-templates`` directory inside the ``manheim_c7n_tools`` installation otherwise. This behavior was largely based on the legacy hard-coded templates directory. Now that c7n-mailer template locations are more flexible, this behavior has been updated to (in order of evaluation):
+
+  * Use the ``templates_folders`` option from the ``mailer_config`` section of ``manheim-c7n-tools.yml``, if present. Otherwise, start with an empty list.
+  * Prepend ``./mailer-templates`` if it exists.
+  * Prepend ``/manheim_c7n_tools/manheim_c7n_tools/mailer-templates`` to the list, if it exists.
+  * Prepend ``mailer-templates`` directory inside the ``manheim_c7n_tools`` installation, if it exists.
+
 0.8.6 (2020-04-07)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-0.8.7 (2020-04-08)
+0.9.0 (2020-04-08)
 ------------------
 
 * Previously, manheim-c7n-tools set c7n-mailer's ``templates_folders`` configuration option to ``/manheim_c7n_tools/manheim_c7n_tools/mailer-templates`` if that directory exists, or to the absolute path to a ``mailer-templates`` directory inside the ``manheim_c7n_tools`` installation otherwise. This behavior was largely based on the legacy hard-coded templates directory. Now that c7n-mailer template locations are more flexible, this behavior has been updated to (in order of evaluation):

--- a/manheim_c7n_tools/runner.py
+++ b/manheim_c7n_tools/runner.py
@@ -287,20 +287,19 @@ class MailerStep(BaseStep):
         conf = deepcopy(self.config.mailer_config)
         jsonschema.validate(conf, MAILER_SCHEMA)
         mailer_setup_defaults(conf)
-        if os.path.isdir(
-            '/manheim_c7n_tools/manheim_c7n_tools/mailer-templates'
-        ):
-            conf['templates_folders'] = [
-                '/manheim_c7n_tools/manheim_c7n_tools/mailer-templates'
-            ]
-        else:
-            # Running outside of Docker
-            conf['templates_folders'] = [
-                os.path.join(
-                    os.path.dirname(os.path.abspath(__file__)),
-                    'mailer-templates'
-                )
-            ]
+        logger.debug('Default mailer config: %s', conf)
+        if 'templates_folders' not in conf:
+            conf['templates_folders'] = []
+        for d in [
+            '/manheim_c7n_tools/manheim_c7n_tools/mailer-templates',
+            os.path.join(
+                os.path.dirname(os.path.abspath(__file__)),
+                'mailer-templates'
+            )
+        ]:
+            if os.path.isdir(d):
+                conf['templates_folders'].insert(0, d)
+        logger.info('Generated mailer config: %s', conf)
         return conf
 
     def run(self):

--- a/manheim_c7n_tools/runner.py
+++ b/manheim_c7n_tools/runner.py
@@ -291,6 +291,7 @@ class MailerStep(BaseStep):
         if 'templates_folders' not in conf:
             conf['templates_folders'] = []
         for d in [
+            os.path.abspath('./mailer-templates'),
             '/manheim_c7n_tools/manheim_c7n_tools/mailer-templates',
             os.path.join(
                 os.path.dirname(os.path.abspath(__file__)),

--- a/manheim_c7n_tools/tests/test_runner.py
+++ b/manheim_c7n_tools/tests/test_runner.py
@@ -264,8 +264,6 @@ class TestMailerStep(StepTester):
         def se_isdir(d):
             if d == '/manheim_c7n_tools/manheim_c7n_tools/mailer-templates':
                 return True
-            if d == '/abspath/path/to/mailer-templates':
-                return False
             return False
 
         def se_abspath(p):
@@ -316,8 +314,6 @@ class TestMailerStep(StepTester):
             d['templates_folders'] = []
 
         def se_isdir(d):
-            if d == '/manheim_c7n_tools/manheim_c7n_tools/mailer-templates':
-                return False
             if d == '/abspath/path/to/mailer-templates':
                 return True
             return False
@@ -347,6 +343,213 @@ class TestMailerStep(StepTester):
             'mailer': 'config',
             'defaults': 'set',
             'templates_folders': ['/abspath/path/to/mailer-templates']
+        }
+        assert res == expected
+        assert mock_validate.mock_calls == [
+            call(expected, MAILER_SCHEMA)
+        ]
+        assert mock_msd.mock_calls == [
+            call(expected)
+        ]
+
+    @patch(f'{pbm}.__file__', 'path/to/runner.py')
+    def test_mailer_config_existing_folders(self):
+        m_conf = Mock(spec_set=ManheimConfig)
+        type(m_conf).mailer_config = PropertyMock(
+            return_value={'mailer': 'config'}
+        )
+
+        def se_mailer_setup_defaults(d):
+            d['defaults'] = 'set'
+            d['templates_folders'] = ['/my/folder']
+
+        def se_isdir(d):
+            if d == '/abspath/path/to/mailer-templates':
+                return True
+            return False
+
+        def se_abspath(p):
+            return f'/abspath/{p}'
+
+        with patch(
+            '%s.jsonschema.validate' % pbm, autospec=True
+        ) as mock_validate:
+            with patch(
+                '%s.mailer_setup_defaults' % pbm, autospec=True
+            ) as mock_msd:
+                mock_msd.side_effect = se_mailer_setup_defaults
+                with patch(
+                    '%s.os.path.isdir' % pbm
+                ) as mock_isdir:
+                    mock_isdir.side_effect = se_isdir
+                    with patch(
+                        '%s.os.path.abspath' % pbm
+                    ) as mock_abspath:
+                        mock_abspath.side_effect = se_abspath
+                        res = runner.MailerStep(
+                            'rName', m_conf
+                        ).mailer_config
+        expected = {
+            'mailer': 'config',
+            'defaults': 'set',
+            'templates_folders': [
+                '/abspath/path/to/mailer-templates',
+                '/my/folder'
+            ]
+        }
+        assert res == expected
+        assert mock_validate.mock_calls == [
+            call(expected, MAILER_SCHEMA)
+        ]
+        assert mock_msd.mock_calls == [
+            call(expected)
+        ]
+
+    @patch(f'{pbm}.__file__', 'path/to/runner.py')
+    def test_mailer_config_only_existing(self):
+        m_conf = Mock(spec_set=ManheimConfig)
+        type(m_conf).mailer_config = PropertyMock(
+            return_value={'mailer': 'config'}
+        )
+
+        def se_mailer_setup_defaults(d):
+            d['defaults'] = 'set'
+            d['templates_folders'] = ['/my/folder']
+
+        def se_isdir(d):
+            return False
+
+        def se_abspath(p):
+            return f'/abspath/{p}'
+
+        with patch(
+            '%s.jsonschema.validate' % pbm, autospec=True
+        ) as mock_validate:
+            with patch(
+                '%s.mailer_setup_defaults' % pbm, autospec=True
+            ) as mock_msd:
+                mock_msd.side_effect = se_mailer_setup_defaults
+                with patch(
+                    '%s.os.path.isdir' % pbm
+                ) as mock_isdir:
+                    mock_isdir.side_effect = se_isdir
+                    with patch(
+                        '%s.os.path.abspath' % pbm
+                    ) as mock_abspath:
+                        mock_abspath.side_effect = se_abspath
+                        res = runner.MailerStep(
+                            'rName', m_conf
+                        ).mailer_config
+        expected = {
+            'mailer': 'config',
+            'defaults': 'set',
+            'templates_folders': [
+                '/my/folder'
+            ]
+        }
+        assert res == expected
+        assert mock_validate.mock_calls == [
+            call(expected, MAILER_SCHEMA)
+        ]
+        assert mock_msd.mock_calls == [
+            call(expected)
+        ]
+
+    @patch(f'{pbm}.__file__', 'path/to/runner.py')
+    def test_mailer_config_pwd(self):
+        m_conf = Mock(spec_set=ManheimConfig)
+        type(m_conf).mailer_config = PropertyMock(
+            return_value={'mailer': 'config'}
+        )
+
+        def se_mailer_setup_defaults(d):
+            d['defaults'] = 'set'
+
+        def se_isdir(d):
+            if d == '/abspath/./mailer-templates':
+                return True
+            return False
+
+        def se_abspath(p):
+            return f'/abspath/{p}'
+
+        with patch(
+            '%s.jsonschema.validate' % pbm, autospec=True
+        ) as mock_validate:
+            with patch(
+                '%s.mailer_setup_defaults' % pbm, autospec=True
+            ) as mock_msd:
+                mock_msd.side_effect = se_mailer_setup_defaults
+                with patch(
+                    '%s.os.path.isdir' % pbm
+                ) as mock_isdir:
+                    mock_isdir.side_effect = se_isdir
+                    with patch(
+                        '%s.os.path.abspath' % pbm
+                    ) as mock_abspath:
+                        mock_abspath.side_effect = se_abspath
+                        res = runner.MailerStep(
+                            'rName', m_conf
+                        ).mailer_config
+        expected = {
+            'mailer': 'config',
+            'defaults': 'set',
+            'templates_folders': [
+                '/abspath/./mailer-templates'
+            ]
+        }
+        assert res == expected
+        assert mock_validate.mock_calls == [
+            call(expected, MAILER_SCHEMA)
+        ]
+        assert mock_msd.mock_calls == [
+            call(expected)
+        ]
+
+    @patch(f'{pbm}.__file__', 'path/to/runner.py')
+    def test_mailer_config_all_exist(self):
+        m_conf = Mock(spec_set=ManheimConfig)
+        type(m_conf).mailer_config = PropertyMock(
+            return_value={'mailer': 'config'}
+        )
+
+        def se_mailer_setup_defaults(d):
+            d['defaults'] = 'set'
+            d['templates_folders'] = ['/my/folder']
+
+        def se_isdir(d):
+            return True
+
+        def se_abspath(p):
+            return f'/abspath/{p}'
+
+        with patch(
+            '%s.jsonschema.validate' % pbm, autospec=True
+        ) as mock_validate:
+            with patch(
+                '%s.mailer_setup_defaults' % pbm, autospec=True
+            ) as mock_msd:
+                mock_msd.side_effect = se_mailer_setup_defaults
+                with patch(
+                    '%s.os.path.isdir' % pbm
+                ) as mock_isdir:
+                    mock_isdir.side_effect = se_isdir
+                    with patch(
+                        '%s.os.path.abspath' % pbm
+                    ) as mock_abspath:
+                        mock_abspath.side_effect = se_abspath
+                        res = runner.MailerStep(
+                            'rName', m_conf
+                        ).mailer_config
+        expected = {
+            'mailer': 'config',
+            'defaults': 'set',
+            'templates_folders': [
+                '/abspath/path/to/mailer-templates',
+                '/manheim_c7n_tools/manheim_c7n_tools/mailer-templates',
+                '/abspath/./mailer-templates',
+                '/my/folder'
+            ]
         }
         assert res == expected
         assert mock_validate.mock_calls == [

--- a/manheim_c7n_tools/version.py
+++ b/manheim_c7n_tools/version.py
@@ -17,7 +17,7 @@ manheim-c7n-tools version configuration.
 """
 
 #: The semver-compliant version of the package.
-VERSION = '0.8.7'
+VERSION = '0.9.0'
 
 #: The URL for further information about the package.
 PROJECT_URL = 'https://github.com/manheim/manheim-c7n-tools'

--- a/manheim_c7n_tools/version.py
+++ b/manheim_c7n_tools/version.py
@@ -17,7 +17,7 @@ manheim-c7n-tools version configuration.
 """
 
 #: The semver-compliant version of the package.
-VERSION = '0.8.6'
+VERSION = '0.8.7'
 
 #: The URL for further information about the package.
 PROJECT_URL = 'https://github.com/manheim/manheim-c7n-tools'


### PR DESCRIPTION
## Description

* Previously, manheim-c7n-tools set c7n-mailer's ``templates_folders`` configuration option (where to find the c7n-mailer templates) to ``/manheim_c7n_tools/manheim_c7n_tools/mailer-templates`` if that directory exists, or to the absolute path to a ``mailer-templates`` directory inside the ``manheim_c7n_tools`` installation otherwise. This behavior was largely based on the legacy hard-coded templates directory. Now that c7n-mailer template locations are more flexible, and version 0.8.5 of this tool added the ability to layer templates into ``./mailer-templates``, this behavior has been updated to (in order of evaluation):

  * Use the ``templates_folders`` option from the ``mailer_config`` section of ``manheim-c7n-tools.yml``, if present. Otherwise, start with an empty list.
  * Prepend ``./mailer-templates`` if it exists.
  * Prepend ``/manheim_c7n_tools/manheim_c7n_tools/mailer-templates`` to the list, if it exists.
  * Prepend ``mailer-templates`` directory inside the ``manheim_c7n_tools`` installation, if it exists.

## Testing Done

Manual local testing (using the saved workspace of an example Jenkins job) and unit tests.