### PR TITLE
if policy_source_paths is specified, include the policy sources in policies.rst

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.9.1 (2020-04-20)
+------------------
+
+* If the ``policy_source_paths`` configuration option is specified, have policygen include a column showing which source(s) a policy came from in ``policies.rst``.
+
 0.9.0 (2020-04-08)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Changelog
 ------------------
 
 * If the ``policy_source_paths`` configuration option is specified, have policygen include a column showing which source(s) a policy came from in ``policies.rst``.
+* Fix bug in ``dryrun-diff`` step where it would fail on an initial, empty S3 bucket.
 
 0.9.0 (2020-04-08)
 ------------------

--- a/manheim_c7n_tools/dryrun_diff.py
+++ b/manheim_c7n_tools/dryrun_diff.py
@@ -232,6 +232,12 @@ class DryRunDiffer(object):
         )
         if response['IsTruncated']:
             raise RuntimeError('ERROR: S3 response was truncated!')
+        if 'CommonPrefixes' not in response:
+            logger.error(
+                'ERROR: "CommonPrefixes" element not in S3 ListObjects '
+                'response; bucket must be empty!'
+            )
+            return []
         result = []
         for pname in response['CommonPrefixes']:
             result.append(pname['Prefix'].replace('logs/', '').strip('/'))

--- a/manheim_c7n_tools/version.py
+++ b/manheim_c7n_tools/version.py
@@ -17,7 +17,7 @@ manheim-c7n-tools version configuration.
 """
 
 #: The semver-compliant version of the package.
-VERSION = '0.9.0'
+VERSION = '0.9.1'
 
 #: The URL for further information about the package.
 PROJECT_URL = 'https://github.com/manheim/manheim-c7n-tools'


### PR DESCRIPTION
## Description

``policygen`` generates an RST file listing each policy, its description (comment), and which accounts and regions it runs in. This does not, however, take into account the policy layering provided by ``policy_source_paths``.

After this PR, if ``policy_source_paths`` is specified and non-empty, the ``policies.rst`` file generated by policygen will include an additional ``Source Path(s)`` column showing which source paths each policy came from.

## Testing Done

* Unit tests
* Manual tests - see below

### Master or no policy_source_paths

```rst
+-----------------------------------------------+--------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
| Policy Name                                   | Account(s) / Region(s)   | Description/Comment                                                                                                                             |
+===============================================+==========================+=================================================================================================================================================+
| ami-old-used-report                           |                          | Report on old AMIs that are being used                                                                                                          |
+-----------------------------------------------+--------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
| asg-ec2-tag-compliance                        |                          | Report on ASG EC2 Instances missing required tags                                                                                               |
+-----------------------------------------------+--------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
| asg-inactive-delete                           |                          | DATA COLLECTION ONLY - Delete marked empty ASGs with old Launch Configs.                                                                        |
+-----------------------------------------------+--------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
| ec2-low-utilization-mark                      |                          | EC2 Instances with low utilization (in any AZ) - notify via email and mark to terminate in 14 days. Look at 2 days worth of data.               |
+-----------------------------------------------+--------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
```

### This branch

```rst
+-----------------------------------------------+--------------------------+-------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
| Policy Name                                   | Account(s) / Region(s)   | Source Path(s)                            | Description/Comment                                                                                                                             |
+===============================================+==========================+===========================================+=================================================================================================================================================+
| ami-old-used-report                           |                          | custodian-man-common                      | Report on old AMIs that are being used                                                                                                          |
+-----------------------------------------------+--------------------------+-------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
| asg-ec2-tag-compliance                        |                          | custodian-man-legacy                      | Report on ASG EC2 Instances missing required tags                                                                                               |
+-----------------------------------------------+--------------------------+-------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
| asg-inactive-delete                           |                          | custodian-man-dev                         | DATA COLLECTION ONLY - Delete marked empty ASGs with old Launch Configs.                                                                        |
+-----------------------------------------------+--------------------------+-------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
| ec2-low-utilization-mark                      |                          | custodian-man-common custodian-man-legacy | EC2 Instances with low utilization (in any AZ) - notify via email and mark to terminate in 14 days. Look at 2 days worth of data.               |
+-----------------------------------------------+--------------------------+-------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------+
```
