### PR TITLE
Add m2r dependency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.9.2 (2020-04-20)
+------------------
+
+* Add ``m2r`` package as dependency, for Sphinx docs builds.
+
 0.9.1 (2020-04-20)
 ------------------
 

--- a/manheim_c7n_tools/version.py
+++ b/manheim_c7n_tools/version.py
@@ -17,7 +17,7 @@ manheim-c7n-tools version configuration.
 """
 
 #: The semver-compliant version of the package.
-VERSION = '0.9.1'
+VERSION = '0.9.2'
 
 #: The URL for further information about the package.
 PROJECT_URL = 'https://github.com/manheim/manheim-c7n-tools'

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ requires = [
     'c7n-mailer==0.5.7',
     # for building generated policy docs
     'sphinx>=1.8.0,<1.9.0',
-    'sphinx_rtd_theme'
+    'sphinx_rtd_theme',
+    'm2r'
 ]
 
 classifiers = [


### PR DESCRIPTION
## Description

This PR adds the ``m2r`` (markdown 2 rst) package as a dependency, as it is helpful during the ``docs`` build step.

## Testing Done

None. Just added a dependency. Local testing only.