### PR TITLE
Update c7n and c7n-mailer versions, bump Python versions used for Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,10 @@ jobs:
       python: '3.8'
       env: TOXENV=py38
     - stage: test
-      python: '3.7'
+      python: '3.8'
       env: TOXENV=docs
     - stage: test
-      python: '3.7'
+      python: '3.8'
       env: TOXENV=docker
     - stage: deploy
       python: '3.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,11 @@ stages:
 jobs:
   include:
     - stage: test
-      python: '3.6'
-      env: TOXENV=py36
-    - stage: test
       python: '3.7'
       env: TOXENV=py37
+    - stage: test
+      python: '3.8'
+      env: TOXENV=py38
     - stage: test
       python: '3.7'
       env: TOXENV=docs

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,9 +6,10 @@ Changelog
 
 **Important:** In following upstream c7n's `0.9.1.0 release <https://github.com/cloud-custodian/cloud-custodian/releases/tag/0.9.1.0>`__, this release drops support for Python 2.7. A modern version of Python 3 is now required.
 
-* Upgrade `c7n-mailer <https://github.com/cloud-custodian/cloud-custodian/tree/master/tools/c7n_mailer>`__ requirement from 0.5.7 to 0.6.0
-* Upgrade ``c7n`` requirement from 0.8.46.0 to 0.9.1.0
-* Switch TravisCI tests from py36 and py37 to py37 and py38
+* Upgrade `c7n-mailer <https://github.com/cloud-custodian/cloud-custodian/tree/master/tools/c7n_mailer>`__ requirement from 0.5.7 to 0.6.0.
+* Upgrade ``c7n`` requirement from 0.8.46.0 to 0.9.1.0.
+* Switch TravisCI tests from py36 and py37 to py37 and py38.
+* Update vendored-in ``mugc`` with latest upstream version, for compatibility with above changes.
 
 0.9.2 (2020-04-20)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+0.10.0 (2020-05-06)
+-------------------
+
+**Important:** In following upstream c7n's `0.9.1.0 release <https://github.com/cloud-custodian/cloud-custodian/releases/tag/0.9.1.0>`__, this release drops support for Python 2.7. A modern version of Python 3 is now required.
+
+* Upgrade `c7n-mailer <https://github.com/cloud-custodian/cloud-custodian/tree/master/tools/c7n_mailer>`__ requirement from 0.5.7 to 0.6.0
+* Upgrade ``c7n`` requirement from 0.8.46.0 to 0.9.1.0
+
 0.9.2 (2020-04-20)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Changelog
 
 * Upgrade `c7n-mailer <https://github.com/cloud-custodian/cloud-custodian/tree/master/tools/c7n_mailer>`__ requirement from 0.5.7 to 0.6.0
 * Upgrade ``c7n`` requirement from 0.8.46.0 to 0.9.1.0
+* Switch TravisCI tests from py36 and py37 to py37 and py38
 
 0.9.2 (2020-04-20)
 ------------------

--- a/manheim_c7n_tools/runner.py
+++ b/manheim_c7n_tools/runner.py
@@ -38,6 +38,7 @@ import boto3
 
 from c7n.commands import validate, run
 from c7n.config import Config
+from c7n.policy import PolicyCollection
 from c7n_mailer.cli import session_factory
 from c7n_mailer.cli import CONFIG_SCHEMA as MAILER_SCHEMA
 from c7n_mailer.utils import setup_defaults as mailer_setup_defaults
@@ -49,7 +50,7 @@ from manheim_c7n_tools.utils import (
 from manheim_c7n_tools.version import VERSION, PROJECT_URL
 from manheim_c7n_tools.policygen import PolicyGen
 from manheim_c7n_tools.vendor.mugc import (
-    load_policies, resources_gc_prefix, resources
+    load_policies, resources_gc_prefix, AWS
 )
 from manheim_c7n_tools.dryrun_diff import DryRunDiffer
 from manheim_c7n_tools.s3_archiver import S3Archiver
@@ -173,12 +174,15 @@ class MugcStep(BaseStep):
     name = 'mugc'
 
     def run(self):
+        # This is largely based off of mugc.main()
         logging.getLogger('botocore').setLevel(logging.ERROR)
+        logging.getLogger('urllib3').setLevel(logging.ERROR)
         logging.getLogger('c7n.cache').setLevel(logging.WARNING)
         conf = Config.empty(
             config_files=['custodian_%s.yml' % self.region_name],
-            region=self.region_name,
+            regions=[self.region_name],
             prefix='custodian-',
+            policy_regex='^custodian-.*',
             assume=None,
             policy_filter=None,
             log_group=None,
@@ -186,17 +190,29 @@ class MugcStep(BaseStep):
             cache_period=0,
             cache=None
         )
-        resources.load_resources()
-        policies = load_policies(conf)
-        resources_gc_prefix(conf, policies)
+        # use cloud provider to initialize policies to get region expansion
+        policies = AWS().initialize_policies(
+            PolicyCollection(
+                [
+                    p for p in load_policies(conf, conf)
+                    if p.provider_name == 'aws'
+                ],
+                conf
+            ),
+            conf
+        )
+        resources_gc_prefix(conf, conf, policies)
 
     def dryrun(self):
+        # This is largely based off of mugc.main()
         logging.getLogger('botocore').setLevel(logging.ERROR)
+        logging.getLogger('urllib3').setLevel(logging.ERROR)
         logging.getLogger('c7n.cache').setLevel(logging.WARNING)
         conf = Config.empty(
             config_files=['custodian_%s.yml' % self.region_name],
-            region=self.region_name,
+            regions=[self.region_name],
             prefix='custodian-',
+            policy_regex='^custodian-.*',
             assume=None,
             policy_filter=None,
             log_group=None,
@@ -205,9 +221,18 @@ class MugcStep(BaseStep):
             cache=None,
             dryrun=True
         )
-        resources.load_resources()
-        policies = load_policies(conf)
-        resources_gc_prefix(conf, policies)
+        # use cloud provider to initialize policies to get region expansion
+        policies = AWS().initialize_policies(
+            PolicyCollection(
+                [
+                    p for p in load_policies(conf, conf)
+                    if p.provider_name == 'aws'
+                ],
+                conf
+            ),
+            conf
+        )
+        resources_gc_prefix(conf, conf, policies)
 
 
 class CustodianStep(BaseStep):

--- a/manheim_c7n_tools/runner.py
+++ b/manheim_c7n_tools/runner.py
@@ -188,7 +188,8 @@ class MugcStep(BaseStep):
             log_group=None,
             external_id=None,
             cache_period=0,
-            cache=None
+            cache=None,
+            present=False
         )
         # use cloud provider to initialize policies to get region expansion
         policies = AWS().initialize_policies(
@@ -219,6 +220,7 @@ class MugcStep(BaseStep):
             external_id=None,
             cache_period=0,
             cache=None,
+            present=False,
             dryrun=True
         )
         # use cloud provider to initialize policies to get region expansion

--- a/manheim_c7n_tools/tests/test_runner.py
+++ b/manheim_c7n_tools/tests/test_runner.py
@@ -152,7 +152,8 @@ class TestMugcStep(StepTester):
                 log_group=None,
                 external_id=None,
                 cache_period=0,
-                cache=None
+                cache=None,
+                present=False
             )
         ]
         assert mocks['load_policies'].mock_calls == [
@@ -204,6 +205,7 @@ class TestMugcStep(StepTester):
                 external_id=None,
                 cache_period=0,
                 cache=None,
+                present=False,
                 dryrun=True
             )
         ]

--- a/manheim_c7n_tools/vendor/mugc.py
+++ b/manheim_c7n_tools/vendor/mugc.py
@@ -1,9 +1,9 @@
 """
 This file was copied verbatim from the cloud-custodian source,
-``tools/ops/mugc.py``, as of the 0.8.30.0 tag. They're not included in the
+``tools/ops/mugc.py``, as of the 0.9.1.0 tag. They're not included in the
 custodian Python package, only in the git repo, so we need to vendor them in.
 """
-# Copyright 2016-2017 Capital One Services, LLC
+# Copyright 2016-2018 Capital One Services, LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,50 +16,62 @@ custodian Python package, only in the git repo, so we need to vendor them in.
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import argparse
 import itertools
 import json
 import os
+import re
 import logging
 import sys
 
 from c7n.credentials import SessionFactory
-from c7n.policy import load as policy_load
-from c7n import mu, resources
+from c7n.config import Config
+from c7n.policy import load as policy_load, PolicyCollection
+from c7n import mu
 
+# TODO: mugc has alot of aws assumptions
+
+from c7n.resources.aws import AWS
+import boto3
 from botocore.exceptions import ClientError
 
-log = logging.getLogger('resources')
+
+log = logging.getLogger('mugc')
 
 
-def load_policies(options):
-    policies = []
+def load_policies(options, config):
+    policies = PolicyCollection([], config)
     for f in options.config_files:
-        collection = policy_load(options, f)
-        policies.extend(collection.filter(options.policy_filter))
+        policies += policy_load(config, f).filter(options.policy_filter)
     return policies
 
 
-def resources_gc_prefix(options, policy_collection):
-    """Garbage collect old custodian policies based on prefix.
+def region_gc(options, region, policy_config, policies):
 
-    We attempt to introspect to find the event sources for a policy
-    but without the old configuration this is implicit.
-    """
     session_factory = SessionFactory(
-        options.region, options.profile, options.assume_role)
+        region=region,
+        assume_role=policy_config.assume_role,
+        profile=policy_config.profile,
+        external_id=policy_config.external_id)
 
     manager = mu.LambdaManager(session_factory)
     funcs = list(manager.list_functions(options.prefix))
-
     client = session_factory().client('lambda')
 
     remove = []
-    current_policies = [p.name for p in policy_collection]
+    current_policies = [p.name for p in policies]
+    pattern = re.compile(options.policy_regex)
     for f in funcs:
-        pn = f['FunctionName'].split('-', 1)[1]
-        if pn not in current_policies:
+        if not pattern.match(f['FunctionName']):
+            continue
+        match = False
+        for pn in current_policies:
+            if f['FunctionName'].endswith(pn):
+                match = True
+        if options.present:
+            if match:
+                remove.append(f)
+        elif not match:
             remove.append(f)
 
     for n in remove:
@@ -68,11 +80,13 @@ def resources_gc_prefix(options, policy_collection):
             result = client.get_policy(FunctionName=n['FunctionName'])
         except ClientError as e:
             if e.response['Error']['Code'] == 'ResourceNotFoundException':
-                log.warn("Lambda Function or Access Policy Statement missing: {}".
-                    format(n['FunctionName']))
+                log.warning(
+                    "Region:%s Lambda Function or Access Policy Statement missing: %s",
+                    region, n['FunctionName'])
             else:
-                log.warn("Unexpected error: {} for function {}".
-                    format(e, n['FunctionName']))
+                log.warning(
+                    "Region:%s Unexpected error: %s for function %s",
+                    region, e, n['FunctionName'])
 
             # Continue on with next function instead of raising an exception
             continue
@@ -103,12 +117,41 @@ def resources_gc_prefix(options, policy_collection):
             'runtime': n['Runtime'],
             'events': events}, None)
 
-        log.info("Removing %s" % n['FunctionName'])
+        log.info("Region:%s Removing %s", region, n['FunctionName'])
         if options.dryrun:
             log.info("Dryrun skipping removal")
             continue
         manager.remove(f)
-        log.info("Removed %s" % n['FunctionName'])
+        log.info("Region:%s Removed %s", region, n['FunctionName'])
+
+
+def resources_gc_prefix(options, policy_config, policy_collection):
+    """Garbage collect old custodian policies based on prefix.
+
+    We attempt to introspect to find the event sources for a policy
+    but without the old configuration this is implicit.
+    """
+
+    # Classify policies by region
+    policy_regions = {}
+    for p in policy_collection:
+        if p.execution_mode == 'poll':
+            continue
+        policy_regions.setdefault(p.options.region, []).append(p)
+
+    regions = get_gc_regions(options.regions)
+    for r in regions:
+        region_gc(options, r, policy_config, policy_regions.get(r, []))
+
+
+def get_gc_regions(regions):
+    if 'all' in regions:
+        session = boto3.Session(
+            region_name='us-east-1',
+            aws_access_key_id='never',
+            aws_secret_access_key='found')
+        return session.get_available_regions('s3')
+    return regions
 
 
 def setup_parser():
@@ -116,17 +159,25 @@ def setup_parser():
     parser.add_argument("configs", nargs='*', help="Policy configuration file(s)")
     parser.add_argument(
         '-c', '--config', dest="config_files", nargs="*", action='append',
-        help="Policy configuration files(s)")
+        help="Policy configuration files(s)", default=[])
     parser.add_argument(
-        '-r', '--region', default=os.environ.get(
-            'AWS_DEFAULT_REGION', 'us-east-1'))
+        "--present", action="store_true", default=False,
+        help='Target policies present in config files for removal instead of skipping them.')
+    parser.add_argument(
+        '-r', '--region', action='append', dest='regions', metavar='REGION',
+        help="AWS Region to target. Can be used multiple times, also supports `all`")
     parser.add_argument('--dryrun', action="store_true", default=False)
     parser.add_argument(
         "--profile", default=os.environ.get('AWS_PROFILE'),
         help="AWS Account Config File Profile to utilize")
     parser.add_argument(
         "--prefix", default="custodian-",
-        help="AWS Account Config File Profile to utilize")
+        help="The Lambda name prefix to use for clean-up")
+    parser.add_argument(
+        "--policy-regex",
+        help="The policy must match the regex")
+    parser.add_argument("-p", "--policies", default=None, dest='policy_filter',
+                        help="Only use named/matched policies")
     parser.add_argument(
         "--assume", default=None, dest="assume_role",
         help="Role to assume")
@@ -140,11 +191,6 @@ def main():
     parser = setup_parser()
     options = parser.parse_args()
 
-    options.policy_filter = None
-    options.log_group = None
-    options.external_id = None
-    options.cache_period = 0
-    options.cache = None
     log_level = logging.INFO
     if options.verbose:
         log_level = logging.DEBUG
@@ -152,20 +198,39 @@ def main():
         level=log_level,
         format="%(asctime)s: %(name)s:%(levelname)s %(message)s")
     logging.getLogger('botocore').setLevel(logging.ERROR)
+    logging.getLogger('urllib3').setLevel(logging.ERROR)
     logging.getLogger('c7n.cache').setLevel(logging.WARNING)
+
+    if not options.policy_regex:
+        options.policy_regex = f"^{options.prefix}.*"
+
+    if not options.regions:
+        options.regions = [os.environ.get('AWS_DEFAULT_REGION', 'us-east-1')]
 
     files = []
     files.extend(itertools.chain(*options.config_files))
     files.extend(options.configs)
     options.config_files = files
+
     if not files:
         parser.print_help()
         sys.exit(1)
 
-    resources.load_resources()
+    policy_config = Config.empty(
+        regions=options.regions,
+        profile=options.profile,
+        assume_role=options.assume_role)
 
-    policies = load_policies(options)
-    resources_gc_prefix(options, policies)
+    # use cloud provider to initialize policies to get region expansion
+    policies = AWS().initialize_policies(
+        PolicyCollection([
+            p for p in load_policies(
+                options, policy_config)
+            if p.provider_name == 'aws'],
+            policy_config),
+        policy_config)
+
+    resources_gc_prefix(options, policy_config, policies)
 
 
 if __name__ == '__main__':

--- a/manheim_c7n_tools/version.py
+++ b/manheim_c7n_tools/version.py
@@ -17,7 +17,7 @@ manheim-c7n-tools version configuration.
 """
 
 #: The semver-compliant version of the package.
-VERSION = '0.9.2'
+VERSION = '0.10.0'
 
 #: The URL for further information about the package.
 PROJECT_URL = 'https://github.com/manheim/manheim-c7n-tools'

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,8 @@ with open('README.md') as f:
     long_description = f.read()
 
 requires = [
-    'boto3',
+    'boto3==1.12.47',
+    'botocore==1.15.47',
     'docutils>=0.10,<0.16',
     'tabulate>=0.8.0,<0.9.0',
     # In order to work with the "mu" Lambda function management tool,

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ requires = [
     # In order to work with the "mu" Lambda function management tool,
     # we need PyYAML 3.x, and need it as source and not a wheel
     'pyyaml',
-    'c7n==0.8.46.0',
-    'c7n-mailer==0.5.7',
+    'c7n==0.9.1.0',
+    'c7n-mailer==0.6.0',
     # for building generated policy docs
     'sphinx>=1.8.0,<1.9.0',
     'sphinx_rtd_theme',

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open('README.md') as f:
 
 requires = [
     'boto3',
-    'docutils>=0.10,<0.15',
+    'docutils>=0.10,<0.16',
     'tabulate>=0.8.0,<0.9.0',
     # In order to work with the "mu" Lambda function management tool,
     # we need PyYAML 3.x, and need it as source and not a wheel

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,docs,docker
+envlist = py37,py38,docs,docker
 
 [testenv]
 deps =
@@ -47,7 +47,7 @@ setenv =
 deps =
   -rrequirements.txt
   -rdocs/requirements.txt
-basepython = python3.7
+basepython = python3.8
 commands_pre =
     # install c7n-mailer, which needs to be from source...
     #{toxinidir}/tox_install_mailer.sh {envdir}
@@ -66,6 +66,7 @@ commands =
 setenv =
     TOXINIDIR={toxinidir}
     TOXDISTDIR={distdir}
+basepython = python3.8
 commands =
     python --version
     virtualenv --version


### PR DESCRIPTION
## Description

This PR updates our c7n and c7n-mailer versions to the latest releases, and also bumps TravisCI testing from py36/py37 to py37/py38.

Note that ``vendor/mugc.py`` has been copied directly from upstream.

## Testing Done

* Automated unit tests and Docker build
* dry-run using this image with an internal repo; see link in Slack