### PR TITLE
Install from git, to get fix for missing jsonpointer and jsonpatch deps

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git/
+.idea/
+.tox/
+assets/
+htmlcov/
+__pycache__
+venv/
+.coverage

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,17 @@
 Changelog
 =========
 
+0.10.2 (2020-05-11)
+-------------------
+
+* Install c7n and c7n-mailer directly from github, instead of PyPI, to pull in unreleased-but-merged `b7178be <https://github.com/cloud-custodian/cloud-custodian/commit/b7178be718bd8c8bdb70b2376d3bb0d5eb6fa9a9>`__ / `PR #5708 <https://github.com/cloud-custodian/cloud-custodian/pull/5708>`__ which fixes `Issue #5707 <https://github.com/cloud-custodian/cloud-custodian/issues/5707>`__ for missing ``jsonpointer`` and ``jsonpatch`` dependencies.
+* Remove ``jsonpointer`` from requirements.
+
+0.10.1 (2020-05-08)
+-------------------
+
+* Add ``jsonpointer`` to requirements.
+
 0.10.0 (2020-05-06)
 -------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Changelog
 
 * Install c7n and c7n-mailer directly from github, instead of PyPI, to pull in unreleased-but-merged `b7178be <https://github.com/cloud-custodian/cloud-custodian/commit/b7178be718bd8c8bdb70b2376d3bb0d5eb6fa9a9>`__ / `PR #5708 <https://github.com/cloud-custodian/cloud-custodian/pull/5708>`__ which fixes `Issue #5707 <https://github.com/cloud-custodian/cloud-custodian/issues/5707>`__ for missing ``jsonpointer`` and ``jsonpatch`` dependencies.
 * Remove ``jsonpointer`` from requirements.
+* Add ``libffi-dev`` and ``openssl-dev`` build dependencies to Dockerfile.
+* Add ``.dockerignore`` file to make Docker builds more efficient.
 
 0.10.1 (2020-05-08)
 -------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ RUN cd /manheim_c7n_tools \
       linux-headers \
       make \
       musl-dev \
+      libffi-dev \
+      openssl-dev \
   && pip install -r requirements.txt \
   && pip install -e . \
   # clean up build dependencies

--- a/manheim_c7n_tools/version.py
+++ b/manheim_c7n_tools/version.py
@@ -17,7 +17,7 @@ manheim-c7n-tools version configuration.
 """
 
 #: The semver-compliant version of the package.
-VERSION = '0.10.0'
+VERSION = '0.10.2'
 
 #: The URL for further information about the package.
 PROJECT_URL = 'https://github.com/manheim/manheim-c7n-tools'

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,7 @@ tabulate>=0.8.0,<0.9.0
 pyyaml
 # for building generated policy docs
 sphinx>=1.8.0,<1.9.0
-jsonpointer==2.0
+# @TODO Bump this to a released version once c7n-mailer > 0.6.0 is out.
+# We're pulling in this git branch in order to pull in https://github.com/cloud-custodian/cloud-custodian/pull/5708
+-e git+https://github.com/cloud-custodian/cloud-custodian.git@b7178be718bd8c8bdb70b2376d3bb0d5eb6fa9a9#egg=c7n
+-e git+https://github.com/cloud-custodian/cloud-custodian.git@b7178be718bd8c8bdb70b2376d3bb0d5eb6fa9a9#egg=c7n-mailer&subdirectory=tools/c7n_mailer

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,8 @@ requires = [
     # In order to work with the "mu" Lambda function management tool,
     # we need PyYAML 3.x, and need it as source and not a wheel
     'pyyaml',
+    # @TODO Bump this to a released version once c7n-mailer > 0.6.0 is out.
+    # We're pulling in this git branch in order to pull in https://github.com/cloud-custodian/cloud-custodian/pull/5708
     'c7n==0.9.1.0',
     'c7n-mailer==0.6.0',
     # for building generated policy docs


### PR DESCRIPTION
## Description

The mailer in this project / Docker image is currently broken because of upstream https://github.com/cloud-custodian/cloud-custodian/issues/5707 where c7n-mailer failed to declare its dependency on ``jsonpointer`` and ``jsonpatch``, causing mailer to fail to run. This was fixed in https://github.com/cloud-custodian/cloud-custodian/pull/5708 upstream, which has been merged to master but not yet released (the release will be done whenever https://github.com/cloud-custodian/cloud-custodian/pull/5734 is merged).

This PR goes back to installing c7n and c7n-mailer from upstream git, in order to pull in this fix. Once there's a new upstream release, we'll revert these changes and bump to the latest upstream version.

## Testing Done

Automated tests via tox show the install is now pulling in ``jsonpatch==1.25`` and ``jsonpointer==2.0``.