### PR TITLE
Fixes #41 - fix for mailer exception

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,9 +1,10 @@
 Changelog
 =========
 
-Unreleased
-----------
+0.10.3 (2020-05-12)
+-------------------
 
+* Bump c7n and c7n-mailer installed version to `b62af99 <https://github.com/cloud-custodian/cloud-custodian/commit/b62af99171bf1163413d7f7411e4a0db8a50f27e>`__ in order to pull in `PR #5751 <https://github.com/cloud-custodian/cloud-custodian/pull/5751>`__, fix for `#5750 <https://github.com/cloud-custodian/cloud-custodian/issues/5750>`__ c7n-mailer critical bug.
 * Add unit test to ensure that the ``c7n-mailer`` Lambda package archive can be successfully generated.
 * Add ``pip freeze`` to the end of Docker image tests, to keep a record of the packages installed in Docker in the build logs.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+* Add unit test to ensure that the ``c7n-mailer`` Lambda package archive can be successfully generated.
+* Add ``pip freeze`` to the end of Docker image tests, to keep a record of the packages installed in Docker in the build logs.
+
 0.10.2 (2020-05-11)
 -------------------
 

--- a/dockertest.sh
+++ b/dockertest.sh
@@ -22,4 +22,4 @@ if [ -z "$1" ]; then
 fi
 
 docker run -it --rm "$1" \
-  bash -c "policygen -V && s3-archiver -V && dryrun-diff -V && manheim-c7n-runner -V && mugc --help && errorscan -V"
+  bash -c "policygen -V && s3-archiver -V && dryrun-diff -V && manheim-c7n-runner -V && mugc --help && errorscan -V && pip freeze"

--- a/manheim_c7n_tools/tests/test_runner.py
+++ b/manheim_c7n_tools/tests/test_runner.py
@@ -25,6 +25,8 @@ import manheim_c7n_tools.runner as runner
 from manheim_c7n_tools.runner import BaseStep
 from manheim_c7n_tools.utils import bold
 from manheim_c7n_tools.config import ManheimConfig
+from c7n_mailer.deploy import get_archive
+from c7n.mu import PythonPackageArchive
 
 pbm = 'manheim_c7n_tools.runner'
 
@@ -658,6 +660,18 @@ class TestMailerStep(StepTester):
                 assert runner.MailerStep.run_in_region(rname, m_conf) is True
             else:
                 assert runner.MailerStep.run_in_region(rname, m_conf) is False
+
+    def test_mailer_archive(self):
+        """
+        This is a test of ``c7n_mailer.deploy.get_archive()``. We've had a few
+        dependency issues in the past that aren't detected until actually
+        deploying mailer and generating the archive (zip) for the Lambda, so
+        this attempts to detect those issues.
+        """
+        arch = get_archive({'templates_folders': []})
+        assert isinstance(arch, PythonPackageArchive)
+        assert arch.size > 0
+        assert len(arch.get_filenames()) > 0
 
 
 class TestDryRunDiffStep(StepTester):

--- a/manheim_c7n_tools/version.py
+++ b/manheim_c7n_tools/version.py
@@ -17,7 +17,7 @@ manheim-c7n-tools version configuration.
 """
 
 #: The semver-compliant version of the package.
-VERSION = '0.10.2'
+VERSION = '0.10.3'
 
 #: The URL for further information about the package.
 PROJECT_URL = 'https://github.com/manheim/manheim-c7n-tools'

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ pyyaml
 sphinx>=1.8.0,<1.9.0
 # @TODO Bump this to a released version once c7n-mailer > 0.6.0 is out.
 # We're pulling in this git branch in order to pull in https://github.com/cloud-custodian/cloud-custodian/pull/5708
--e git+https://github.com/cloud-custodian/cloud-custodian.git@b7178be718bd8c8bdb70b2376d3bb0d5eb6fa9a9#egg=c7n
--e git+https://github.com/cloud-custodian/cloud-custodian.git@b7178be718bd8c8bdb70b2376d3bb0d5eb6fa9a9#egg=c7n-mailer&subdirectory=tools/c7n_mailer
+-e git+https://github.com/cloud-custodian/cloud-custodian.git@b62af99171bf1163413d7f7411e4a0db8a50f27e#egg=c7n
+-e git+https://github.com/cloud-custodian/cloud-custodian.git@b62af99171bf1163413d7f7411e4a0db8a50f27e#egg=c7n-mailer&subdirectory=tools/c7n_mailer


### PR DESCRIPTION
## Description

This bumps the version of c7n that we're installing from upstream git to [b62af99](https://github.com/cloud-custodian/cloud-custodian/commit/b62af99171bf1163413d7f7411e4a0db8a50f27e) in order to pull in [PR \#5751](https://github.com/cloud-custodian/cloud-custodian/pull/5751), fix for [\#5750](https://github.com/cloud-custodian/cloud-custodian/issues/5750) c7n-mailer critical bug.

It also adds a unit test to ensure that the upstream mailer archive generation works so we don't have a bug like this before.

## Testing Done

Unit tests and automated build.