### PR TITLE
changelog for PR #34 merge, and version bump to 1.0.0

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+1.0.0 (2020-05-26)
+------------------
+
+* Merge `PR #34 <https://github.com/manheim/manheim-c7n-tools/pull/34>`__ to add an optional full HTML report to the ``dryrun-diff`` step/entrypoint, triggered by the presence of a ``reporting-template/report.j2`` template file. Many thanks to `@JuubiSnake <https://github.com/JuubiSnake>`__ of `FundingCircle <https://github.com/FundingCircle>`__ for the contribution.
+* In recognition of this project being used extensively in our organization, bump version to 1.0.0.
+
 0.10.3 (2020-05-12)
 -------------------
 

--- a/manheim_c7n_tools/version.py
+++ b/manheim_c7n_tools/version.py
@@ -17,7 +17,7 @@ manheim-c7n-tools version configuration.
 """
 
 #: The semver-compliant version of the package.
-VERSION = '0.10.3'
+VERSION = '1.0.0'
 
 #: The URL for further information about the package.
 PROJECT_URL = 'https://github.com/manheim/manheim-c7n-tools'


### PR DESCRIPTION
## Description

This adds a CHANGES entry for the merge of #34 and also bumps the version to 1.0.0, in recognition of our extensive use internally.

## Testing Done

Automated tests.