### PR TITLE
Add ability to disable rules, as well as fix a bug in ruleset merging.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,6 +57,7 @@ coverage.xml
 
 # Sphinx documentation
 docs/build/
+docs/_build/
 
 # PyBuilder
 target/

--- a/docs/source/policygen.rst
+++ b/docs/source/policygen.rst
@@ -104,6 +104,15 @@ Overriding rules
 
 Overriding rules is based on naming. **Rules will not be merged, only replaced.** If a rule appears in a lower repository it will replace a rule with the same name in a higher repository.
 
+Disabling rules
+---------------
+
+Rules from higher-level rulesets can be disabled by creating a new rule with the same name and setting a ``disabled`` key for that rule to ``true``.
+
+.. code:: yaml
+    name: rule-name
+    disabled: true
+
 Mailer Templates
 ----------------
 

--- a/manheim_c7n_tools/policygen.py
+++ b/manheim_c7n_tools/policygen.py
@@ -148,22 +148,26 @@ class PolicyGen(object):
 
     def _merge_configs(self, target, source):
         new_config = deepcopy(target)
-        for acctname in source:
-            if acctname in new_config:
-                for region in source[acctname]:
-                    if region in new_config[acctname]:
-                        for rule in source[acctname][region]:
-                            if rule in new_config[acctname][region]:
-                                new_config[acctname][region][rule] \
-                                    .update(source[acctname][region][rule])
+        for account in source:
+            if account in new_config:
+                for region in source[account]:
+                    if region in new_config[account]:
+                        for rule in source[account][region]:
+                            logger.info("Rule: " + rule)
+                            disable = source[account][region][rule].get(
+                                "disable", False
+                            )
+                            if disable is True:
+                                if rule in new_config[account][region]:
+                                    del new_config[account][region][rule]
                             else:
-                                new_config[acctname][region][rule] = \
-                                    deepcopy(source[acctname][region][rule])
+                                new_config[account][region][rule] = \
+                                    deepcopy(source[account][region][rule])
                     else:
-                        new_config[acctname][region] = \
-                            deepcopy(source[acctname][region])
+                        new_config[account][region] = \
+                            deepcopy(source[account][region])
             else:
-                new_config[acctname] = deepcopy(source[acctname])
+                new_config[account] = deepcopy(source[account])
         return new_config
 
     def _load_policy(self, path=''):

--- a/manheim_c7n_tools/tests/test_policygen.py
+++ b/manheim_c7n_tools/tests/test_policygen.py
@@ -1297,7 +1297,7 @@ class TestMergeConfigs(PolicyGenTester):
             'myAccount': {
                 'region1': {
                     'rule1': {
-                        'foo': 'bar-myAccount/region1'
+                        'bar': 'baz-myAccount/region1'
                     },
                     'rule2': {
                         'baz': 'blam'
@@ -1320,7 +1320,42 @@ class TestMergeConfigs(PolicyGenTester):
         }
 
         res = self.cls._merge_configs(target, source)
+        assert 'foo' not in res['myAccount']['region1']['rule1']
+        assert res['myAccount']['region1']['rule1']['bar'] == \
+            'baz-myAccount/region1'
         assert res['myAccount']['region1']['rule2']['baz'] == 'blam'
+
+    def test_rule_disable(self):
+        source = {
+            'myAccount': {
+                'region1': {
+                    'rule1': {
+                        'bar': 'baz-myAccount/region1'
+                    },
+                    'rule2': {
+                        'disable': True
+                    }
+                }
+            }
+        }
+
+        target = {
+            'myAccount': {
+                'region1': {
+                    'rule1': {
+                        'foo': 'bar-myAccount/region1'
+                    },
+                    'rule2': {
+                        'baz': 'bang'
+                    }
+                }
+            }
+        }
+
+        res = self.cls._merge_configs(target, source)
+        assert 'rule2' not in res['myAccount']['region1']
+        assert res['myAccount']['region1']['rule1']['bar'] == \
+            'baz-myAccount/region1'
 
 
 class TestLoadAllPolicies(PolicyGenTester):


### PR DESCRIPTION
Currently, merging rulesets does not properly replace existing rules with new ones. Instead, it merges the rules
together resulting in potentially nonsense rules.

## Description

The current implementation does not properly replace existing rules from layered rulesets.

This PR fixes that issue, as well as adding the ability to disable rules from higher-level rulesets completely.

## Testing Done

Local testing, as well as new tox tests for both disabling rules and merging rulesets.

## Contributor License Agreement

Required for external contributors.

By submitting this work for inclusion in manheim-c7n-tools, I agree to the following terms:

* The contribution included in this request (and any subsequent revisions or versions of it)
  is being made under the same license as the manheim-c7n-tools project (Apache v2).
* My contribution may perpetually be included in and distributed with manheim-c7n-tools; submitting
  this pull request grants a perpetual, global, unlimited license for it to be used and distributed
  under the terms of manheim-c7n-tools's license.
* I have the legal power and rights to agree to these terms.