### PR TITLE
Release v1.2.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+1.2.1 (2020-06-25)
+------------------
+
+* Bump c7n and c7n-mailer installed version to `26ba07e <https://github.com/cloud-custodian/cloud-custodian/commit/26ba07ea569dfe320682f7509082fc9bead0ca4c>`__ in order to pull in `PR #5893 <https://github.com/cloud-custodian/cloud-custodian/pull/5893>`__, fix for `#5854 <https://github.com/cloud-custodian/cloud-custodian/issues/5854>`__ c7n config splunk sourcetype.
+* Bump c7n and c7n-mailer versions in setup.py to match the latest versions released
+
 1.2.0 (2020-06-22)
 ------------------
 

--- a/manheim_c7n_tools/version.py
+++ b/manheim_c7n_tools/version.py
@@ -17,7 +17,7 @@ manheim-c7n-tools version configuration.
 """
 
 #: The semver-compliant version of the package.
-VERSION = '1.2.0'
+VERSION = '1.2.1'
 
 #: The URL for further information about the package.
 PROJECT_URL = 'https://github.com/manheim/manheim-c7n-tools'

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,10 +4,12 @@ tabulate>=0.8.0,<0.9.0
 pyyaml
 # for building generated policy docs
 sphinx>=1.8.0,<1.9.0
-c7n==0.9.3
-c7n-mailer==0.6.2
 # to match up with c7n / c7n-mailer dependencies
 boto3==1.13.24
 botocore==1.16.24
 docutils==0.15.2
 jmespath==0.9.5
+# @TODO Bump this to a released version once c7n > 0.9.3 and c7n-mailer > 0.6.2 is out.
+# We're pulling in this git branch in order to pull in https://github.com/cloud-custodian/cloud-custodian/pull/5893
+-e git+https://github.com/cloud-custodian/cloud-custodian.git@26ba07ea569dfe320682f7509082fc9bead0ca4c#egg=c7n
+-e git+https://github.com/cloud-custodian/cloud-custodian.git@26ba07ea569dfe320682f7509082fc9bead0ca4c#egg=c7n-mailer&subdirectory=tools/c7n_mailer

--- a/setup.py
+++ b/setup.py
@@ -12,10 +12,8 @@ requires = [
     # In order to work with the "mu" Lambda function management tool,
     # we need PyYAML 3.x, and need it as source and not a wheel
     'pyyaml',
-    # @TODO Bump this to a released version once c7n-mailer > 0.6.0 is out.
-    # We're pulling in this git branch in order to pull in https://github.com/cloud-custodian/cloud-custodian/pull/5708
-    'c7n==0.9.1.0',
-    'c7n-mailer==0.6.0',
+    'c7n==0.9.3',
+    'c7n-mailer==0.6.2',
     # for building generated policy docs
     'sphinx>=1.8.0,<1.9.0',
     'sphinx_rtd_theme',


### PR DESCRIPTION
## Description

Release v1.2.1
Pull pinned c7n commit to resolve issue of Splunk HEC source type not being configurable. See https://github.com/cloud-custodian/cloud-custodian/pull/5893

## Contributor License Agreement

Required for external contributors.

By submitting this work for inclusion in manheim-c7n-tools, I agree to the following terms:

* The contribution included in this request (and any subsequent revisions or versions of it)
  is being made under the same license as the manheim-c7n-tools project (Apache v2).
* My contribution may perpetually be included in and distributed with manheim-c7n-tools; submitting
  this pull request grants a perpetual, global, unlimited license for it to be used and distributed
  under the terms of manheim-c7n-tools's license.
* I have the legal power and rights to agree to these terms.
