### PR TITLE
Add `disable` state to generated policy documentation

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,5 +1,9 @@
 Changelog
 =========
+1.2.3 (2020-07-10)
+------------------
+
+* Update policygen to add enabled/disabled status to generated policy documentation
 
 1.2.2 (2020-07-08)
 ------------------

--- a/docs/source/policies.rst
+++ b/docs/source/policies.rst
@@ -413,6 +413,32 @@ Other keys under the ``mode`` section include:
 -  **execution\_options** - Internal options of the Lambda function. Our defaults send logs to a CloudWatch log group
    and output to an S3 bucket, and setup the Dead Letter Queue.
 
+.. _`policies.disable`:
+
+Disabling a policy
+------------------
+
+It is possible to disable a rule. Simply setting the ``disable`` key in a policy to ``true`` will stop that policy from being
+deployed.
+
+.. code:: yaml
+
+    name: onhour-start-ec2
+    comments: Start tagged EC2 Instances daily at 06:00 Eastern, or per tag value
+    resource: ec2
+    disable: true
+
+The ``disable`` key can be added to an existing policy to temporarily disable the policy, and can also be used to disable a
+policy inherited from a higher-level policy source location by creating a new policy with the same name as the inherited
+policy and adding the ``disable`` key. Only the ``name`` and ``disable`` keys are required in this case, though adding about
+comment can help explain why the policy is disabled.
+
+.. code:: yaml
+
+    name: onhour-start-ec2
+    comments: Disabled due to ...
+    disable: true
+
 .. _`policies.action_transition`:
 
 Data Collection/Notification to Action Transition

--- a/example_config_multi_repo/policies/shared/all_accounts/common/disabled-rule.yml
+++ b/example_config_multi_repo/policies/shared/all_accounts/common/disabled-rule.yml
@@ -1,0 +1,19 @@
+# REMINDER: defaults.yml will be merged in to this. See the README.
+name: disabled-rule
+comments: Test rule to test disabling rules.
+resource: log-group
+disable: true
+filters:
+  # custodian- or cloud-custodian- lambda log groups
+  - type: value
+    key: logGroupName
+    op: regex
+    value: "^/aws/lambda/(cloud-custodian-|custodian-)"
+  - type: value
+    key: retentionInDays
+    op: ne
+    value: 30
+actions:
+  # set Log Group retention to 30 days
+  - type: retention
+    days: 30

--- a/example_config_multi_repo/policies/shared/all_accounts/common/disabled-rule.yml
+++ b/example_config_multi_repo/policies/shared/all_accounts/common/disabled-rule.yml
@@ -1,8 +1,7 @@
 # REMINDER: defaults.yml will be merged in to this. See the README.
 name: disabled-rule
-comments: Test rule to test disabling rules.
+comments: Test rule to test disabling rules. This will be disabled by the "team" rule of the same name
 resource: log-group
-disable: true
 filters:
   # custodian- or cloud-custodian- lambda log groups
   - type: value

--- a/example_config_multi_repo/policies/team/one-account/common/disabled-rule.yml
+++ b/example_config_multi_repo/policies/team/one-account/common/disabled-rule.yml
@@ -1,0 +1,4 @@
+# REMINDER: defaults.yml will be merged in to this. See the README.
+name: disabled-rule
+comments: Test rule to test disabling rules. This will disable the "shared" rule of the same name.
+disable: true

--- a/example_config_repo/policies/one-account/common/disabled-rule.yml
+++ b/example_config_repo/policies/one-account/common/disabled-rule.yml
@@ -1,0 +1,19 @@
+# REMINDER: defaults.yml will be merged in to this. See the README.
+name: disabled-rule
+comments: Test rule to test disabling rules.
+resource: log-group
+disable: true
+filters:
+  # custodian- or cloud-custodian- lambda log groups
+  - type: value
+    key: logGroupName
+    op: regex
+    value: "^/aws/lambda/(cloud-custodian-|custodian-)"
+  - type: value
+    key: retentionInDays
+    op: ne
+    value: 30
+actions:
+  # set Log Group retention to 30 days
+  - type: retention
+    days: 30

--- a/manheim_c7n_tools/policygen.py
+++ b/manheim_c7n_tools/policygen.py
@@ -264,22 +264,6 @@ class PolicyGen(object):
         """
         return not(policy.get("disable", False))
 
-    def _map_policies(self, result):
-        """
-        Separates a list of policies into two lists containing enabled and
-        disabled policies.
-
-        :param result: List of policies to map
-        :type result: list
-        """
-        mapped_policies = {"enabled": [], "disabled": []}
-        for policy in result['policies']:
-            if self._is_enabled(policy):
-                mapped_policies['enabled'].append(policy)
-            else:
-                mapped_policies['disabled'].append(policy)
-        return mapped_policies
-
     def _write_custodian_configs(self, result, region_name):
         """
         Write the per-region ``custodian_REGION.yml`` config file to disk. This

--- a/manheim_c7n_tools/tests/test_policygen.py
+++ b/manheim_c7n_tools/tests/test_policygen.py
@@ -3035,6 +3035,21 @@ class TestTimestr(object):
         assert policygen.timestr() == '2018-04-01 01:02:03 UTC'
 
 
+class TestIsEnabled(object):
+
+    def test_is_enabled_not_specified(self):
+        policy = {}
+        assert policygen.is_enabled(policy)
+
+    def test_is_disabled(self):
+        policy = {"disable": True}
+        assert not(policygen.is_enabled(policy))
+
+    def test_is_enabled_specified(self):
+        policy = {"disable": False}
+        assert policygen.is_enabled(policy)
+
+
 class TestMain(object):
 
     def test_main(self):

--- a/manheim_c7n_tools/tests/test_policygen.py
+++ b/manheim_c7n_tools/tests/test_policygen.py
@@ -1726,7 +1726,7 @@ class TestWriteCustodianConfigs(PolicyGenTester):
         clear=True
     )
     def test_write(self):
-        original = {
+        original = {"policies": [{
             'foo': 'bar%%AWS_REGION%%baz',
             'bar': [
                 'baz',
@@ -1741,7 +1741,7 @@ class TestWriteCustodianConfigs(PolicyGenTester):
                     'blarg%%AWS_REGION%%xx': 'xxx%%AWS_REGION%%xxx'
                 }
             }
-        }
+        }]}
         with patch(
             'manheim_c7n_tools.policygen.PolicyGen._write_file', autospec=True
         ) as mock_wf:
@@ -2382,7 +2382,8 @@ class TestPolicyRst(PolicyGenTester):
                     'Policy Name',
                     'Account(s) / Region(s)',
                     'Source Path(s)',
-                    'Description/Comment'
+                    'Description/Comment',
+                    'Enabled'
                 ],
                 tablefmt='grid'
             )
@@ -2439,7 +2440,8 @@ class TestPolicyRst(PolicyGenTester):
                 headers=[
                     'Policy Name',
                     'Account(s) / Region(s)',
-                    'Description/Comment'
+                    'Description/Comment',
+                    'Enabled'
                 ],
                 tablefmt='grid'
             )
@@ -2499,52 +2501,62 @@ class TestPolicyRstData(PolicyGenTester):
             [
                 'all_common',
                 '',
-                'region3'
+                'region3',
+                True
             ],
             [
                 'all_r1',
                 'myAccount (region1) otherAccount (region1)',
-                'region1'
+                'region1',
+                True
             ],
             [
                 'all_r2',
                 'myAccount (region2) otherAccount (region2)',
-                'region2'
+                'region2',
+                True
             ],
             [
                 'all_r3',
                 'myAccount (region3) otherAccount (region3)',
-                'region3'
+                'region3',
+                True
             ],
             [
                 'baz',
                 'myAccount (region1 region2) otherAccount (region2 region3)',
-                'blam'
+                'blam',
+                True
             ],
             [
                 'foo',
                 'myAccount (region3) otherAccount (region1)',
-                'bar-otherAccount/region1'
+                'bar-otherAccount/region1',
+                True
             ],
             [
                 'fooA1',
                 'myAccount (region1 region2)',
-                'bar-myAccount/region2'
+                'bar-myAccount/region2',
+                True
             ],
             [
                 'fooA2',
                 'otherAccount (region2 region3)',
-                'bar-otherAccount/region3'
+                'bar-otherAccount/region3',
+                True
             ],
             [
                 'myAccount/common',
                 'myAccount',
-                'c'
+                'c',
+                True
             ],
             [
                 'otherAccount/common',
                 'otherAccount',
-                'c'
+                'c',
+                True
             ]
         ]
 
@@ -2612,61 +2624,71 @@ class TestPolicyRstData(PolicyGenTester):
                 'all_common',
                 '',
                 'path1',
-                'region3'
+                'region3',
+                True
             ],
             [
                 'all_r1',
                 'myAccount (region1) otherAccount (region1)',
                 'path2',
-                'region1'
+                'region1',
+                True
             ],
             [
                 'all_r2',
                 'myAccount (region2) otherAccount (region2)',
                 'path2',
-                'region2'
+                'region2',
+                True
             ],
             [
                 'all_r3',
                 'myAccount (region3) otherAccount (region3)',
                 'path3',
-                'region3'
+                'region3',
+                True
             ],
             [
                 'baz',
                 'myAccount (region1 region2) otherAccount (region2 region3)',
                 'path1 path2',
-                'blam'
+                'blam',
+                True
             ],
             [
                 'foo',
                 'myAccount (region3) otherAccount (region1)',
                 'path1 path2 path3',
-                'bar-otherAccount/region1'
+                'bar-otherAccount/region1',
+                True
             ],
             [
                 'fooA1',
                 'myAccount (region1 region2)',
                 'path1',
-                'bar-myAccount/region2'
+                'bar-myAccount/region2',
+                True
             ],
             [
                 'fooA2',
                 'otherAccount (region2 region3)',
                 'path1',
-                'bar-otherAccount/region3'
+                'bar-otherAccount/region3',
+                True
             ],
             [
                 'myAccount/common',
                 'myAccount',
                 'path2',
-                'c'
+                'c',
+                True
             ],
             [
                 'otherAccount/common',
                 'otherAccount',
                 'path3',
-                'c'
+                'c',
+                True
             ]
         ]
 

--- a/manheim_c7n_tools/version.py
+++ b/manheim_c7n_tools/version.py
@@ -17,7 +17,7 @@ manheim-c7n-tools version configuration.
 """
 
 #: The semver-compliant version of the package.
-VERSION = '1.2.2'
+VERSION = '1.2.3'
 
 #: The URL for further information about the package.
 PROJECT_URL = 'https://github.com/manheim/manheim-c7n-tools'


### PR DESCRIPTION
## Description

This PR adds support for documenting disabled rules to the generated policy documentation.

## Testing Done

New unit tests, local testing using the example repos included in this project. A new disabled rule was added to both example sets.

## Contributor License Agreement

Required for external contributors.

By submitting this work for inclusion in manheim-c7n-tools, I agree to the following terms:

* The contribution included in this request (and any subsequent revisions or versions of it)
  is being made under the same license as the manheim-c7n-tools project (Apache v2).
* My contribution may perpetually be included in and distributed with manheim-c7n-tools; submitting
  this pull request grants a perpetual, global, unlimited license for it to be used and distributed
  under the terms of manheim-c7n-tools's license.
* I have the legal power and rights to agree to these terms.
