### PR TITLE
Bump to latest c7n and c7n-mailer releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,9 @@ jobs:
       python: '3.8'
       env: TOXENV=py38
     - stage: test
+      python: '3.9'
+      env: TOXENV=py39
+    - stage: test
       python: '3.8'
       env: TOXENV=docs
     - stage: test

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Unreleased
 ----------
 
 * Fixes `#56 <https://github.com/manheim/manheim-c7n-tools/issues/56>`__ - Bump c7n version from 0.9.4 to `0.9.10 <https://github.com/cloud-custodian/cloud-custodian/releases/tag/0.9.10.0>`__ and c7n-mailer from 0.6.3 to 0.6.9.
+* Bump relax boto3 and botocore dependencies to work with c7n and new pip resolver.
 * Begin testing against Python 3.9
 * Bump base Docker image to latest ``python:3.9.1-alpine3.12``
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 * Fixes `#56 <https://github.com/manheim/manheim-c7n-tools/issues/56>`__ - Bump c7n version from 0.9.4 to `0.9.9 <https://github.com/cloud-custodian/cloud-custodian/releases/tag/0.9.9.0>`__ and c7n-mailer from 0.6.3 to 0.6.8.
 * Begin testing against Python 3.9
+* Bump base Docker image to latest ``python:3.9.1-alpine3.12``
 
 1.2.4 (2020-07-29)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+1.3.0 (2020-12-16)
+------------------
+
+* Fixes `#56 <https://github.com/manheim/manheim-c7n-tools/issues/56>`__ - Bump c7n version from 0.9.4 to `0.9.9 <https://github.com/cloud-custodian/cloud-custodian/releases/tag/0.9.9.0>`__ and c7n-mailer from 0.6.3 to 0.6.8. 
+
 1.2.4 (2020-07-29)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 1.3.0 (2020-12-16)
 ------------------
 
-* Fixes `#56 <https://github.com/manheim/manheim-c7n-tools/issues/56>`__ - Bump c7n version from 0.9.4 to `0.9.9 <https://github.com/cloud-custodian/cloud-custodian/releases/tag/0.9.9.0>`__ and c7n-mailer from 0.6.3 to 0.6.8. 
+* Fixes `#56 <https://github.com/manheim/manheim-c7n-tools/issues/56>`__ - Bump c7n version from 0.9.4 to `0.9.9 <https://github.com/cloud-custodian/cloud-custodian/releases/tag/0.9.9.0>`__ and c7n-mailer from 0.6.3 to 0.6.8.
+* Begin testing against Python 3.9
 
 1.2.4 (2020-07-29)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,10 +1,10 @@
 Changelog
 =========
 
-1.3.0 (2020-12-16)
-------------------
+Unreleased
+----------
 
-* Fixes `#56 <https://github.com/manheim/manheim-c7n-tools/issues/56>`__ - Bump c7n version from 0.9.4 to `0.9.9 <https://github.com/cloud-custodian/cloud-custodian/releases/tag/0.9.9.0>`__ and c7n-mailer from 0.6.3 to 0.6.8.
+* Fixes `#56 <https://github.com/manheim/manheim-c7n-tools/issues/56>`__ - Bump c7n version from 0.9.4 to `0.9.10 <https://github.com/cloud-custodian/cloud-custodian/releases/tag/0.9.10.0>`__ and c7n-mailer from 0.6.3 to 0.6.9.
 * Begin testing against Python 3.9
 * Bump base Docker image to latest ``python:3.9.1-alpine3.12``
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.3-alpine3.9
+FROM python:3.9.1-alpine3.12
 
 ARG git_version
 

--- a/manheim_c7n_tools/version.py
+++ b/manheim_c7n_tools/version.py
@@ -17,7 +17,7 @@ manheim-c7n-tools version configuration.
 """
 
 #: The semver-compliant version of the package.
-VERSION = '1.2.4'
+VERSION = '1.3.0'
 
 #: The URL for further information about the package.
 PROJECT_URL = 'https://github.com/manheim/manheim-c7n-tools'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,8 @@
+c7n==0.9.9
+c7n-mailer==0.6.8
 tabulate>=0.8.0,<0.9.0
 # In order to work with the "mu" Lambda function management tool,
 # we need PyYAML 3.x, and need it as source and not a wheel
 pyyaml
 # for building generated policy docs
 sphinx>=1.8.0,<1.9.0
-c7n==0.9.4
-c7n-mailer==0.6.3
-# to match up with c7n / c7n-mailer dependencies
-boto3==1.14.16
-botocore==1.17.16
-docutils==0.15.2
-jmespath==0.10.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-c7n==0.9.9
-c7n-mailer==0.6.8
+c7n==0.9.10
+c7n-mailer==0.6.9
 tabulate>=0.8.0,<0.9.0
 # In order to work with the "mu" Lambda function management tool,
 # we need PyYAML 3.x, and need it as source and not a wheel

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ requires = [
     # In order to work with the "mu" Lambda function management tool,
     # we need PyYAML 3.x, and need it as source and not a wheel
     'pyyaml',
-    'c7n==0.9.4',
-    'c7n-mailer==0.6.3',
+    'c7n==0.9.9',
+    'c7n-mailer==0.6.8',
     # for building generated policy docs
     'sphinx>=1.8.0,<1.9.0',
     'sphinx_rtd_theme',

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,8 @@ with open('README.md') as f:
     long_description = f.read()
 
 requires = [
-    'boto3==1.14.16',
-    'botocore==1.17.16',
+    'boto3',
+    'botocore',
     'docutils>=0.10,<0.16',
     'tabulate>=0.8.0,<0.9.0',
     # In order to work with the "mu" Lambda function management tool,

--- a/setup.py
+++ b/setup.py
@@ -12,8 +12,8 @@ requires = [
     # In order to work with the "mu" Lambda function management tool,
     # we need PyYAML 3.x, and need it as source and not a wheel
     'pyyaml',
-    'c7n==0.9.9',
-    'c7n-mailer==0.6.8',
+    'c7n==0.9.10',
+    'c7n-mailer==0.6.9',
     # for building generated policy docs
     'sphinx>=1.8.0,<1.9.0',
     'sphinx_rtd_theme',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,docs,docker
+envlist = py37,py38,py39,docs,docker
 
 [testenv]
 deps =


### PR DESCRIPTION
## Description

This PR fixes #56 by bumping both c7n and c7n-mailer to their latest upstream releases. It also adds python 3.9 test runs, and bumps the base Docker image from python 3.7 to 3.9.

## Testing Done

TBD.