### PR TITLE
Implement notify-only support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,13 +36,13 @@ jobs:
       python: '3.9'
       env: TOXENV=py39
     - stage: test
-      python: '3.8'
+      python: '3.9'
       env: TOXENV=docs
     - stage: test
-      python: '3.8'
+      python: '3.9'
       env: TOXENV=docker
     - stage: deploy
-      python: '3.7'
+      python: '3.9'
       script: bash build_or_deploy.sh build
       after_success: echo after_success
       deploy:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,7 +6,7 @@ Unreleased
 
 * Fixes `#56 <https://github.com/manheim/manheim-c7n-tools/issues/56>`__ - Bump c7n version from 0.9.4 to `0.9.10 <https://github.com/cloud-custodian/cloud-custodian/releases/tag/0.9.10.0>`__ and c7n-mailer from 0.6.3 to 0.6.9.
 * Bump relax boto3 and botocore dependencies to work with c7n and new pip resolver.
-* Begin testing against Python 3.9
+* Add testing under Python 3.9; switch default Python version for tox/TravisCI to 3.9.
 * Bump base Docker image to latest ``python:3.9.1-alpine3.12``
 
 1.2.4 (2020-07-29)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,8 @@
 Changelog
 =========
 
-Unreleased
-----------
+1.3.0 (2021-01-13)
+------------------
 
 * Fixes `#56 <https://github.com/manheim/manheim-c7n-tools/issues/56>`__ - Bump c7n version from 0.9.4 to `0.9.10 <https://github.com/cloud-custodian/cloud-custodian/releases/tag/0.9.10.0>`__ and c7n-mailer from 0.6.3 to 0.6.9.
 * Bump relax boto3 and botocore dependencies to work with c7n and new pip resolver.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Unreleased
 * Bump relax boto3 and botocore dependencies to work with c7n and new pip resolver.
 * Add testing under Python 3.9; switch default Python version for tox/TravisCI to 3.9.
 * Bump base Docker image to latest ``python:3.9.1-alpine3.12``
+* Implement :ref:`policies.notify_only`.
+* Fix failing test.
 
 1.2.4 (2020-07-29)
 ------------------

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -12,11 +12,11 @@ Development
 Local Development and Testing
 =============================
 
-Clone this repo locally on a machine with Python 3.7. Then:
+Clone this repo locally on a machine with Python 3. Then:
 
 .. code-block:: shell
 
-    virtualenv --python=python3.7 .
+    virtualenv --python=python3 .
     source bin/activate
     pip install 'tox>=3.4.0'
     pip install -r requirements.txt

--- a/docs/source/manheim_c7n_tools.notifyonly.rst
+++ b/docs/source/manheim_c7n_tools.notifyonly.rst
@@ -1,0 +1,7 @@
+manheim\_c7n\_tools.notifyonly module
+=====================================
+
+.. automodule:: manheim_c7n_tools.notifyonly
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/docs/source/manheim_c7n_tools.rst
+++ b/docs/source/manheim_c7n_tools.rst
@@ -21,6 +21,7 @@ Submodules
    manheim_c7n_tools.config
    manheim_c7n_tools.dryrun_diff
    manheim_c7n_tools.errorscan
+   manheim_c7n_tools.notifyonly
    manheim_c7n_tools.policygen
    manheim_c7n_tools.runner
    manheim_c7n_tools.s3_archiver

--- a/docs/source/policies.rst
+++ b/docs/source/policies.rst
@@ -502,7 +502,7 @@ As described above in :ref:`policies.action_transition`, it's common to want to 
 
 To support this, manheim-c7n-tools (specifically :ref:`policygen`) supports the addition of a boolean ``notify_only`` option at the top level of policy files, or in ``defaults.yml`` for account- / repository-wide notify-only. Setting this flag will cause :ref:`policygen` to pass the effected policies through :py:class:`~.NotifyOnlyPolicy` for pre-processing. This will cause the following changes to the final YAML policy:
 
-* The ``comment`` / ``comments`` / ``description`` fields will be prefixed with the string ``NOTIFY ONLY: ``
+* The ``comment`` / ``comments`` / ``description`` fields will be prefixed with the string ``NOTIFY ONLY:``
 * If the policy has a ``tags`` list, a ``notify-only`` tag will be appended to it.
 * All tagging actions will have the string ``-notify-only`` appended to their tag names, to automate the above-described transition. Specifically:
 
@@ -510,5 +510,5 @@ To support this, manheim-c7n-tools (specifically :ref:`policygen`) supports the 
   * Any ``mark-for-op`` actions will have the string ``-notify-only`` appended to their ``tag`` value. If they do not already have a ``tag`` value, it will be set to custodian's ``DEFAULT_TAG`` value, with ``-notify-only`` appended.
   * Any ``remove-tag`` / ``unmark`` / ``untag`` actions wukk have the string ``-notify-only`` appended to all items in their ``tags`` list.
 
-* All ``notify`` actions will have their ``violation_desc``, if present, prefixed with ``NOTIFY ONLY: ``. Their ``action_desc``, if present, will be prefixed with ``in the future (currently notify-only)``.
+* All ``notify`` actions will have their ``violation_desc``, if present, prefixed with ``NOTIFY ONLY:``. Their ``action_desc``, if present, will be prefixed with ``in the future (currently notify-only)``.
 * All other action types, not listed above, will be **removed from the policy**. We enforce notify-only by only retaining specifically whitelisted actions in the policy.

--- a/docs/source/policies.rst
+++ b/docs/source/policies.rst
@@ -510,4 +510,5 @@ To support this, manheim-c7n-tools (specifically :ref:`policygen`) supports the 
   * Any ``mark-for-op`` actions will have the string ``-notify-only`` appended to their ``tag`` value. If they do not already have a ``tag`` value, it will be set to custodian's ``DEFAULT_TAG`` value, with ``-notify-only`` appended.
   * Any ``remove-tag`` / ``unmark`` / ``untag`` actions wukk have the string ``-notify-only`` appended to all items in their ``tags`` list.
 
+* All ``notify`` actions will have their ``violation_desc``, if present, prefixed with ``NOTIFY ONLY: ``. Their ``action_desc``, if present, will be prefixed with ``in the future (currently notify-only)``.
 * All other action types, not listed above, will be **removed from the policy**. We enforce notify-only by only retaining specifically whitelisted actions in the policy.

--- a/docs/source/policies.rst
+++ b/docs/source/policies.rst
@@ -252,6 +252,8 @@ The full list of top-level keys valid for a policy can be found by viewing the s
    :ref:`Actions <policies.actions>` section, below, for more information.
 -  **mode** - The ``mode`` key determines how the policy will be deployed and run. See the
    :ref:`Mode <policies.mode>` section, below, for more information.
+-  **notify_only** - This is a manheim-c7n-tools addition, which is used internally and removed from the policy before :ref:`policygen` generates the final YAML files for custodian. See :ref:`policies.notify_only` for further information.
+-  **disable** - This is a manheim-c7n-tools addition, which is used internally and removed from the policy before :ref:`policygen` generates the final YAML files for custodian. See :ref:`policies.disable` for further information.
 
 .. _`policies.filters`:
 
@@ -281,6 +283,8 @@ code for each (which is liked from that documentation).
 
 Actions
 -------
+
+.. note:: manheim-c7n-tools' :ref:`policies.notify_only` option on a policy can effect the actions specified. See that section for more information.
 
 Cloud-custodian has both generic/global actions (such as ``notify``) and resource-specific actions
 (such as ``stop`` and ``start``). Some actions are specified as only a string (i.e. ``stop`` or
@@ -418,7 +422,7 @@ Other keys under the ``mode`` section include:
 Disabling a policy
 ------------------
 
-It is possible to disable a rule. Simply setting the ``disable`` key in a policy to ``true`` will stop that policy from being
+It is possible to disable a policy. Simply setting the ``disable`` key in a policy to ``true`` will stop that policy from being
 deployed.
 
 .. code:: yaml
@@ -454,6 +458,13 @@ are later enabled for corresponding policies, the actions might be taken
 immediately when enabled as a result of the "notify only" policies
 marking resources for action.
 
+As of version 1.3.0, manheim-c7n-tools supports a :ref:`policies.notify_only` flag to help simplify this transition. For older versions, or policies that existed prior to 1.3.0, see the following section on manual tag cleanup.
+
+.. _`policies.action_transition_manual_tag_cleanup`:
+
+Manual Tag Cleanup
+------------------
+
 As a result, when adding actions to policies that have been running in
 data collection mode, it's important to manually purge the relevant tags
 so the policies don't take any action based on tags applied during data
@@ -481,3 +492,22 @@ tags with something like (example for EC2 instances):
       echo "removing tag from: $i"
       aws ec2 delete-tags --resources $i --tags Key=$tagname
     done
+
+.. _`policies.notify_only`:
+
+Notify-Only Option for Policies
+===============================
+
+As described above in :ref:`policies.action_transition`, it's common to want to run new policies in a "notify only" mode that sends notifications (and collects data) but does not yet take actions, assess those notifications, and enable actually taking action at a later date.
+
+To support this, manheim-c7n-tools (specifically :ref:`policygen`) supports the addition of a boolean ``notify_only`` option at the top level of policy files, or in ``defaults.yml`` for account- / repository-wide notify-only. Setting this flag will cause :ref:`policygen` to pass the effected policies through :py:class:`~.NotifyOnlyPolicy` for pre-processing. This will cause the following changes to the final YAML policy:
+
+* The ``comment`` / ``comments`` / ``description`` fields will be prefixed with the string ``NOTIFY ONLY: ``
+* If the policy has a ``tags`` list, a ``notify-only`` tag will be appended to it.
+* All tagging actions will have the string ``-notify-only`` appended to their tag names, to automate the above-described transition. Specifically:
+
+  * Any ``mark`` or ``tag`` actions in the actions list will have the string ``-notify-only`` appended to their ``tag`` or ``key`` values (if present) or appended to every item in their ``tags`` list (if present). If none of the above are present, the ``tag`` item will be set to custodian's ``DEFAULT_TAG`` value, with ``-notify-only`` appended.
+  * Any ``mark-for-op`` actions will have the string ``-notify-only`` appended to their ``tag`` value. If they do not already have a ``tag`` value, it will be set to custodian's ``DEFAULT_TAG`` value, with ``-notify-only`` appended.
+  * Any ``remove-tag`` / ``unmark`` / ``untag`` actions wukk have the string ``-notify-only`` appended to all items in their ``tags`` list.
+
+* All other action types, not listed above, will be **removed from the policy**. We enforce notify-only by only retaining specifically whitelisted actions in the policy.

--- a/docs/source/policies.rst
+++ b/docs/source/policies.rst
@@ -511,4 +511,5 @@ To support this, manheim-c7n-tools (specifically :ref:`policygen`) supports the 
   * Any ``remove-tag`` / ``unmark`` / ``untag`` actions wukk have the string ``-notify-only`` appended to all items in their ``tags`` list.
 
 * All ``notify`` actions will have their ``violation_desc``, if present, prefixed with ``NOTIFY ONLY:``. Their ``action_desc``, if present, will be prefixed with ``in the future (currently notify-only)``.
+* Any ``filters`` items with ``tag:NAME`` keys, which match up with ``NAME`` tags used in ``mark-for-op`` actions, will be updated to ``tag:NAME-notify-only`` to retain their intended functionality.
 * All other action types, not listed above, will be **removed from the policy**. We enforce notify-only by only retaining specifically whitelisted actions in the policy.

--- a/docs/source/policygen.rst
+++ b/docs/source/policygen.rst
@@ -113,6 +113,13 @@ Rules from higher-level rulesets can be disabled by creating a new rule with the
     name: rule-name
     disable: true
 
+For further information, see :ref:`policies.disable`.
+
+Notify-Only rules
+-----------------
+
+Policygen also has support for setting rules to a notify-only mode via a single flag. Please see :ref:`policies.notify_only` for further information.
+
 Mailer Templates
 ----------------
 

--- a/manheim_c7n_tools/notifyonly.py
+++ b/manheim_c7n_tools/notifyonly.py
@@ -14,6 +14,7 @@
 
 from typing import List
 import logging
+from c7n.tags import DEFAULT_TAG
 
 logger = logging.getLogger(__name__)
 
@@ -82,12 +83,26 @@ class NotifyOnlyPolicy:
 
     @staticmethod
     def _fix_tag_action(item: dict) -> dict:
+        if 'tag' in item:
+            item['tag'] = item['tag'] + '-notify-only'
+        if 'key' in item:
+            item['key'] = item['key'] + '-notify-only'
+        if 'tags' in item:
+            item['tags'] = {
+                f'{k}-notify-only': v for k, v in item['tags'].items()
+            }
+        if 'tag' not in item and 'key' not in item and 'tags' not in item:
+            item['tag'] = f'{DEFAULT_TAG}-notify-only'
         return item
 
     @staticmethod
     def _fix_mark_for_op_action(item: dict) -> dict:
+        if 'tag' not in item:
+            item['tag'] = DEFAULT_TAG
+        item['tag'] += '-notify-only'
         return item
 
     @staticmethod
     def _fix_untag_action(item: dict) -> dict:
+        item['tags'] = [f'{tag}-notify-only' for tag in item['tags']]
         return item

--- a/manheim_c7n_tools/notifyonly.py
+++ b/manheim_c7n_tools/notifyonly.py
@@ -118,7 +118,24 @@ class NotifyOnlyPolicy:
 
     @staticmethod
     def _fix_notify_action(item: dict) -> dict:
-        raise NotImplementedError()
+        """
+        Fix a ``notify`` action for notify-only operation.
+
+        If the ``violation_desc`` key is present, its value will be prefixed
+        with ``NOTIFY ONLY: ``. If the ``action_desc`` key is present, its value
+        will be prefixed with the string
+        ``in the future (currently notify-only)``.
+
+        :param item: the original action
+        :type item: dict
+        :return: the modified action
+        :rtype: dict
+        """
+        if 'violation_desc' in item:
+            item['violation_desc'] = 'NOTIFY ONLY: ' + item['violation_desc']
+        if 'action_desc' in item:
+            item['action_desc'] = 'in the future (currently notify-only) ' + \
+                                  item['action_desc']
         return item
 
     @staticmethod

--- a/manheim_c7n_tools/notifyonly.py
+++ b/manheim_c7n_tools/notifyonly.py
@@ -1,0 +1,93 @@
+# Copyright 2017-2021 Manheim / Cox Automotive
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import List
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+class NotifyOnlyPolicy:
+    """
+    This class converts a c7n policy to a "notify only" policy. The changes are:
+
+    * Update the comment, comments, and description with a notify-only prefix.
+    * If the policy already has ``tags``, add a "notify-only" tag.
+    * Remove any actions other than: mark, mark-for-op, notify, remove-tag, tag,
+      unmark, untag
+    """
+
+    @staticmethod
+    def as_notify_only(policy: dict) -> dict:
+        """
+        Return the given policy, converted to notify-only.
+
+        :param policy: the original c7n policy
+        :type policy: dict
+        :return: policy, modified for notify-only mode
+        :rtype: dict
+        """
+        if 'notify_only' in policy:
+            del policy['notify_only']
+        for k in policy.keys():
+            if k in ['comment', 'comments', 'description']:
+                policy[k] = NotifyOnlyPolicy._fix_comment(policy[k])
+            if k == 'tags':
+                policy[k] = NotifyOnlyPolicy._fix_tags(policy[k])
+            if k == 'actions':
+                policy[k] = NotifyOnlyPolicy._fix_actions(policy[k])
+        return policy
+
+    @staticmethod
+    def _fix_comment(comment: str) -> str:
+        return f'NOTIFY ONLY: {comment}'
+
+    @staticmethod
+    def _fix_tags(tags: List[str]) -> List[str]:
+        return tags + ['notify-only']
+
+    @staticmethod
+    def _fix_actions(original: List) -> List:
+        result = []
+        for item in original:
+            if not isinstance(item, type({})):
+                logger.info('NotifyOnlyPolicy - removing action: %s', item)
+                continue
+            a_type = item.get('type', '')
+            if a_type == 'notify':
+                result.append(item)
+            if a_type == 'mark' or a_type == 'tag':
+                result.append(NotifyOnlyPolicy._fix_tag_action(item))
+            elif a_type == 'mark-for-op':
+                result.append(NotifyOnlyPolicy._fix_mark_for_op_action(item))
+            elif a_type in ['remove-tag', 'unmark', 'untag']:
+                result.append(NotifyOnlyPolicy._fix_untag_action(item))
+            else:
+                logger.info(
+                    'NotifyOnlyPolicy - removing %s action: %s', a_type, item
+                )
+                continue
+        return result
+
+    @staticmethod
+    def _fix_tag_action(item: dict) -> dict:
+        return item
+
+    @staticmethod
+    def _fix_mark_for_op_action(item: dict) -> dict:
+        return item
+
+    @staticmethod
+    def _fix_untag_action(item: dict) -> dict:
+        return item

--- a/manheim_c7n_tools/notifyonly.py
+++ b/manheim_c7n_tools/notifyonly.py
@@ -197,6 +197,6 @@ class NotifyOnlyPolicy:
         :rtype: dict
         """
         if 'tags' not in item:
-            item['tags'] = [f'{DEFAULT_TAG}-notify-only']
+            item['tags'] = [f'{DEFAULT_TAG}']
         item['tags'] = [f'{tag}-notify-only' for tag in item['tags']]
         return item

--- a/manheim_c7n_tools/notifyonly.py
+++ b/manheim_c7n_tools/notifyonly.py
@@ -196,5 +196,7 @@ class NotifyOnlyPolicy:
         :return: the modified action
         :rtype: dict
         """
+        if 'tags' not in item:
+            item['tags'] = [f'{DEFAULT_TAG}-notify-only']
         item['tags'] = [f'{tag}-notify-only' for tag in item['tags']]
         return item

--- a/manheim_c7n_tools/notifyonly.py
+++ b/manheim_c7n_tools/notifyonly.py
@@ -28,8 +28,26 @@ class NotifyOnlyPolicy:
     :ref:`policies.notify_only` in the documentation.
     """
 
-    @staticmethod
-    def as_notify_only(policy: dict) -> dict:
+    def __init__(self, policy: dict):
+        """
+        Initialize a NotifyOnlyPolicy.
+
+        :param policy: the original policy
+        :type policy: dict
+        """
+        self._original: dict = policy
+        self._fixed: dict = self._process(self._original)
+
+    def as_notify_only(self) -> dict:
+        """
+        Return the policy, converted to a notify-only version.
+
+        :return: converted policy
+        :rtype: dict
+        """
+        return self._fixed
+
+    def _process(self, policy: dict) -> dict:
         """
         Return the given policy, converted to notify-only.
 
@@ -42,15 +60,14 @@ class NotifyOnlyPolicy:
             del policy['notify_only']
         for k in policy.keys():
             if k in ['comment', 'comments', 'description']:
-                policy[k] = NotifyOnlyPolicy._fix_comment(policy[k])
+                policy[k] = self._fix_comment(policy[k])
             if k == 'tags':
-                policy[k] = NotifyOnlyPolicy._fix_tags(policy[k])
+                policy[k] = self._fix_tags(policy[k])
             if k == 'actions':
-                policy[k] = NotifyOnlyPolicy._fix_actions(policy[k])
+                policy[k] = self._fix_actions(policy[k])
         return policy
 
-    @staticmethod
-    def _fix_comment(comment: str) -> str:
+    def _fix_comment(self, comment: str) -> str:
         """
         Convert a policy comment/comments/description to a notify only version,
         by prefixing it with the string "NOTIFY ONLY: ".
@@ -62,8 +79,7 @@ class NotifyOnlyPolicy:
         """
         return f'NOTIFY ONLY: {comment}'
 
-    @staticmethod
-    def _fix_tags(tags: List[str]) -> List[str]:
+    def _fix_tags(self, tags: List[str]) -> List[str]:
         """
         Convert a policy tags list to a notify only version, by appending a
         ``notify-only`` tag to the list.
@@ -75,8 +91,7 @@ class NotifyOnlyPolicy:
         """
         return tags + ['notify-only']
 
-    @staticmethod
-    def _fix_actions(original: List) -> List:
+    def _fix_actions(self, original: List) -> List:
         """
         Given a list of actions from a policy, return a new list of notify-only
         actions.
@@ -102,13 +117,13 @@ class NotifyOnlyPolicy:
                 continue
             a_type = item.get('type', '')
             if a_type == 'notify':
-                result.append(NotifyOnlyPolicy._fix_notify_action(item))
+                result.append(self._fix_notify_action(item))
             if a_type == 'mark' or a_type == 'tag':
-                result.append(NotifyOnlyPolicy._fix_tag_action(item))
+                result.append(self._fix_tag_action(item))
             elif a_type == 'mark-for-op':
-                result.append(NotifyOnlyPolicy._fix_mark_for_op_action(item))
+                result.append(self._fix_mark_for_op_action(item))
             elif a_type in ['remove-tag', 'unmark', 'untag']:
-                result.append(NotifyOnlyPolicy._fix_untag_action(item))
+                result.append(self._fix_untag_action(item))
             else:
                 logger.info(
                     'NotifyOnlyPolicy - removing %s action: %s', a_type, item
@@ -116,8 +131,7 @@ class NotifyOnlyPolicy:
                 continue
         return result
 
-    @staticmethod
-    def _fix_notify_action(item: dict) -> dict:
+    def _fix_notify_action(self, item: dict) -> dict:
         """
         Fix a ``notify`` action for notify-only operation.
 
@@ -138,8 +152,7 @@ class NotifyOnlyPolicy:
                                   item['action_desc']
         return item
 
-    @staticmethod
-    def _fix_tag_action(item: dict) -> dict:
+    def _fix_tag_action(self, item: dict) -> dict:
         """
         Fix a ``tag`` / ``mark`` action for notify-only operation.
 
@@ -166,8 +179,7 @@ class NotifyOnlyPolicy:
             item['tag'] = f'{DEFAULT_TAG}-notify-only'
         return item
 
-    @staticmethod
-    def _fix_mark_for_op_action(item: dict) -> dict:
+    def _fix_mark_for_op_action(self, item: dict) -> dict:
         """
         Fix a ``mark-for-op`` action for notify-only operation.
 
@@ -183,8 +195,7 @@ class NotifyOnlyPolicy:
         item['tag'] += '-notify-only'
         return item
 
-    @staticmethod
-    def _fix_untag_action(item: dict) -> dict:
+    def _fix_untag_action(self, item: dict) -> dict:
         """
         Fix a ``remove-tag`` / ``unmark`` / ``untag`` action for notify-only
         operation.

--- a/manheim_c7n_tools/policygen.py
+++ b/manheim_c7n_tools/policygen.py
@@ -262,7 +262,11 @@ class PolicyGen(object):
             for pol in self._generate_cleanup_policies(
                 deepcopy(result['policies'])
             ):
-                result['policies'].append(self._apply_defaults(defaults, pol))
+                result['policies'].append(
+                    self._handle_notify_only_policy(
+                        self._apply_defaults(defaults, pol)
+                    )
+                )
         logger.info('Checking policies for sanity and safety...')
         self._check_policies(result['policies'])
         self._write_custodian_configs(result, region_name)

--- a/manheim_c7n_tools/policygen.py
+++ b/manheim_c7n_tools/policygen.py
@@ -33,6 +33,7 @@ except ImportError:
 from manheim_c7n_tools.version import VERSION, PROJECT_URL
 from manheim_c7n_tools.config import ManheimConfig
 from manheim_c7n_tools.utils import git_html_url
+from manheim_c7n_tools.notifyonly import NotifyOnlyPolicy
 
 whtspc_re = re.compile(r'\s+')
 
@@ -519,6 +520,12 @@ class PolicyGen(object):
         :return: policy updated as needed
         :rtype: dict
         """
+        if 'notify_only' not in policy:
+            return policy
+        notify_only = policy['notify_only']
+        del policy['notify_only']
+        if notify_only:
+            return NotifyOnlyPolicy.as_notify_only(policy)
         return policy
 
     def _apply_defaults(self, defaults, policy):

--- a/manheim_c7n_tools/policygen.py
+++ b/manheim_c7n_tools/policygen.py
@@ -525,7 +525,7 @@ class PolicyGen(object):
         notify_only = policy['notify_only']
         del policy['notify_only']
         if notify_only:
-            return NotifyOnlyPolicy.as_notify_only(policy)
+            return NotifyOnlyPolicy(policy).as_notify_only()
         return policy
 
     def _apply_defaults(self, defaults, policy):

--- a/manheim_c7n_tools/policygen.py
+++ b/manheim_c7n_tools/policygen.py
@@ -251,7 +251,9 @@ class PolicyGen(object):
         result = {'policies': []}
         for k in sorted(policies.keys()):
             result['policies'].append(
-                self._apply_defaults(defaults, policies[k])
+                self._handle_notify_only_policy(
+                    self._apply_defaults(defaults, policies[k])
+                )
             )
         if self._config.cleanup_notify:
             logger.info('Generating c7n cleanup policies...')
@@ -506,6 +508,18 @@ class PolicyGen(object):
         """write a file - helper to make unit tests simpler"""
         with open(path, 'w') as fh:
             fh.write(content)
+
+    def _handle_notify_only_policy(self, policy):
+        """
+        Given an individual policy configuration dict, if it has ``notify_only``
+        set to True, update the policy accordingly.
+
+        :param policy: policy dict, with defaults applied
+        :type policy: dict
+        :return: policy updated as needed
+        :rtype: dict
+        """
+        return policy
 
     def _apply_defaults(self, defaults, policy):
         d = deepcopy(defaults)

--- a/manheim_c7n_tools/tests/test_config.py
+++ b/manheim_c7n_tools/tests/test_config.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mock import patch, call, Mock, mock_open
+from unittest.mock import patch, call, Mock, mock_open
 import pytest
 import yaml
 

--- a/manheim_c7n_tools/tests/test_notifyonly.py
+++ b/manheim_c7n_tools/tests/test_notifyonly.py
@@ -125,6 +125,30 @@ class TestFixActions:
         ]
 
 
+class TestFixNotifyAction:
+
+    def test_no_description(self):
+        policy = {
+            'type': 'notify',
+            'subject': 'foo'
+        }
+        assert NotifyOnlyPolicy._fix_notify_action(policy) == policy
+
+    def test_description(self):
+        policy = {
+            'type': 'notify',
+            'subject': 'foo',
+            'violation_desc': 'Violation',
+            'action_desc': 'actionDesc'
+        }
+        assert NotifyOnlyPolicy._fix_notify_action(policy) == {
+            'type': 'notify',
+            'subject': 'foo',
+            'violation_desc': 'NOTIFY ONLY: Violation',
+            'action_desc': 'in the future (currently notify-only) actionDesc'
+        }
+
+
 class TestFixTagAction:
 
     def test_tag(self):

--- a/manheim_c7n_tools/tests/test_notifyonly.py
+++ b/manheim_c7n_tools/tests/test_notifyonly.py
@@ -12,11 +12,206 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mock import patch, call, mock_open, DEFAULT, Mock, PropertyMock
-import pytest
-import os
+from unittest.mock import patch, call, DEFAULT
 
 from manheim_c7n_tools.notifyonly import NotifyOnlyPolicy
+from c7n.tags import DEFAULT_TAG
 
 pbm = 'manheim_c7n_tools.notifyonly'
 pb = f'{pbm}.NotifyOnlyPolicy'
+
+
+class TestAsNotifyOnly:
+
+    def test_all(self):
+        policy = {
+            'foo': 'bar',
+            'notify_only': True,
+            'baz': 'blam',
+            'comment': 'commentVal',
+            'comments': 'commentsVal',
+            'description': 'descriptionVal',
+            'tags': ['my', 'tags'],
+            'actions': ['some', 'actions']
+        }
+        with patch(f'{pb}._fix_actions') as mock_fa:
+            mock_fa.return_value = ['updated', 'actions']
+            res = NotifyOnlyPolicy.as_notify_only(policy)
+        assert res == {
+            'foo': 'bar',
+            'baz': 'blam',
+            'comment': 'NOTIFY ONLY: commentVal',
+            'comments': 'NOTIFY ONLY: commentsVal',
+            'description': 'NOTIFY ONLY: descriptionVal',
+            'tags': ['my', 'tags', 'notify-only'],
+            'actions': ['updated', 'actions']
+        }
+        assert mock_fa.mock_calls == [
+            call(['some', 'actions'])
+        ]
+
+    def test_empty_policy(self):
+        policy = {
+            'foo': 'bar',
+            'baz': 'blam',
+        }
+        with patch(f'{pb}._fix_actions') as mock_fa:
+            mock_fa.return_value = ['updated', 'actions']
+            res = NotifyOnlyPolicy.as_notify_only(policy)
+        assert res == {
+            'foo': 'bar',
+            'baz': 'blam',
+        }
+        assert mock_fa.mock_calls == []
+
+
+class TestFixComment:
+
+    def test_simple(self):
+        assert NotifyOnlyPolicy._fix_comment('foo') == 'NOTIFY ONLY: foo'
+
+
+class TestFixTags:
+
+    def test_simple(self):
+        assert NotifyOnlyPolicy._fix_tags(['foo']) == ['foo', 'notify-only']
+
+
+class TestFixActions:
+
+    def test_all(self):
+        actions = [
+            'something',
+            {'type': 'foo'},
+            {'type': 'notify'},
+            {'type': 'mark'},
+            {'type': 'tag'},
+            {'type': 'mark-for-op'},
+            {'type': 'remove-tag'},
+            {'type': 'unmark'},
+            {'type': 'untag'},
+            {'type': 'bar'},
+        ]
+        with patch.multiple(
+            pb,
+            _fix_tag_action=DEFAULT,
+            _fix_mark_for_op_action=DEFAULT,
+            _fix_untag_action=DEFAULT,
+        ) as mocks:
+            mocks['_fix_tag_action'].return_value = {'fixed': 'tag'}
+            mocks['_fix_mark_for_op_action'].return_value = {'fixed': 'op'}
+            mocks['_fix_untag_action'].return_value = {'fixed': 'untag'}
+            res = NotifyOnlyPolicy._fix_actions(actions)
+        assert res == [
+            {'type': 'notify'},
+            {'fixed': 'tag'},
+            {'fixed': 'tag'},
+            {'fixed': 'op'},
+            {'fixed': 'untag'},
+            {'fixed': 'untag'},
+            {'fixed': 'untag'}
+        ]
+        assert mocks['_fix_tag_action'].mock_calls == [
+            call({'type': 'mark'}),
+            call({'type': 'tag'})
+        ]
+        assert mocks['_fix_mark_for_op_action'].mock_calls == [
+            call({'type': 'mark-for-op'})
+        ]
+        assert mocks['_fix_untag_action'].mock_calls == [
+            call({'type': 'remove-tag'}),
+            call({'type': 'unmark'}),
+            call({'type': 'untag'}),
+        ]
+
+
+class TestFixTagAction:
+
+    def test_tag(self):
+        policy = {
+            'action': 'mark',
+            'tag': 'foo',
+            'value': 'bar'
+        }
+        assert NotifyOnlyPolicy._fix_tag_action(policy) == {
+            'action': 'mark',
+            'tag': 'foo-notify-only',
+            'value': 'bar'
+        }
+
+    def test_key(self):
+        policy = {
+            'action': 'mark',
+            'key': 'foo',
+            'value': 'bar'
+        }
+        assert NotifyOnlyPolicy._fix_tag_action(policy) == {
+            'action': 'mark',
+            'key': 'foo-notify-only',
+            'value': 'bar'
+        }
+
+    def test_tags(self):
+        policy = {
+            'action': 'mark',
+            'tags': {'foo': 'bar', 'baz': 'blam'}
+        }
+        assert NotifyOnlyPolicy._fix_tag_action(policy) == {
+            'action': 'mark',
+            'tags': {'foo-notify-only': 'bar', 'baz-notify-only': 'blam'}
+        }
+
+    def test_default_tag(self):
+        policy = {
+            'action': 'mark',
+            'value': 'bar'
+        }
+        assert NotifyOnlyPolicy._fix_tag_action(policy) == {
+            'action': 'mark',
+            'tag': f'{DEFAULT_TAG}-notify-only',
+            'value': 'bar'
+        }
+
+
+class TestFixMarkForOpAction:
+
+    def test_tag_present(self):
+        policy = {
+            'action': 'mark-for-op',
+            'op': 'foo',
+            'tag': 'mytag',
+            'days': 7
+        }
+        assert NotifyOnlyPolicy._fix_mark_for_op_action(policy) == {
+            'action': 'mark-for-op',
+            'op': 'foo',
+            'tag': 'mytag-notify-only',
+            'days': 7
+        }
+
+    def test_tag_not_present(self):
+        policy = {
+            'action': 'mark-for-op',
+            'op': 'foo',
+            'days': 7
+        }
+        assert NotifyOnlyPolicy._fix_mark_for_op_action(policy) == {
+            'action': 'mark-for-op',
+            'op': 'foo',
+            'tag': f'{DEFAULT_TAG}-notify-only',
+            'days': 7
+        }
+
+
+class TestFixUntagAction:
+
+    def test_simple(self):
+        assert NotifyOnlyPolicy._fix_untag_action({
+            'tags': ['foo', 'bar'],
+            'baz': 'blam',
+            'action': 'untag'
+        }) == {
+            'tags': ['foo-notify-only', 'bar-notify-only'],
+            'baz': 'blam',
+            'action': 'untag'
+        }

--- a/manheim_c7n_tools/tests/test_notifyonly.py
+++ b/manheim_c7n_tools/tests/test_notifyonly.py
@@ -1,0 +1,22 @@
+# Copyright 2017-2021 Manheim / Cox Automotive
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from mock import patch, call, mock_open, DEFAULT, Mock, PropertyMock
+import pytest
+import os
+
+from manheim_c7n_tools.notifyonly import NotifyOnlyPolicy
+
+pbm = 'manheim_c7n_tools.notifyonly'
+pb = f'{pbm}.NotifyOnlyPolicy'

--- a/manheim_c7n_tools/tests/test_notifyonly.py
+++ b/manheim_c7n_tools/tests/test_notifyonly.py
@@ -239,3 +239,13 @@ class TestFixUntagAction:
             'baz': 'blam',
             'action': 'untag'
         }
+
+    def test_tags_not_present(self):
+        assert NotifyOnlyPolicy._fix_untag_action({
+            'baz': 'blam',
+            'action': 'untag'
+        }) == {
+            'tags': [f'{DEFAULT_TAG}-notify-only'],
+            'baz': 'blam',
+            'action': 'untag'
+        }

--- a/manheim_c7n_tools/tests/test_policygen.py
+++ b/manheim_c7n_tools/tests/test_policygen.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from mock import patch, call, mock_open, DEFAULT, Mock, PropertyMock
+from unittest.mock import patch, call, mock_open, DEFAULT, Mock, PropertyMock
 import pytest
 import os
 from freezegun import freeze_time

--- a/manheim_c7n_tools/tests/test_policygen.py
+++ b/manheim_c7n_tools/tests/test_policygen.py
@@ -1636,8 +1636,8 @@ class TestGenerateConfigs(PolicyGenTester):
             'policies': [
                 'blam+defaults+notifyonly',
                 'bar+defaults+notifyonly',
-                'cleanup1+defaults',
-                'cleanup2+defaults'
+                'cleanup1+defaults+notifyonly',
+                'cleanup2+defaults+notifyonly'
             ]
         }
         assert mocks['_apply_defaults'].mock_calls == [
@@ -1648,7 +1648,9 @@ class TestGenerateConfigs(PolicyGenTester):
         ]
         assert mocks['_handle_notify_only_policy'].mock_calls == [
             call(self.cls, 'blam+defaults'),
-            call(self.cls, 'bar+defaults')
+            call(self.cls, 'bar+defaults'),
+            call(self.cls, 'cleanup1+defaults'),
+            call(self.cls, 'cleanup2+defaults')
         ]
         assert mocks['_generate_cleanup_policies'].mock_calls == [
             call(
@@ -1660,8 +1662,8 @@ class TestGenerateConfigs(PolicyGenTester):
             'policies': [
                 'blam+defaults+notifyonly',
                 'bar+defaults+notifyonly',
-                'cleanup1+defaults',
-                'cleanup2+defaults'
+                'cleanup1+defaults+notifyonly',
+                'cleanup2+defaults+notifyonly'
             ]
         }
         assert mocks['_write_custodian_configs'].mock_calls == [
@@ -1673,8 +1675,8 @@ class TestGenerateConfigs(PolicyGenTester):
                 [
                     'blam+defaults+notifyonly',
                     'bar+defaults+notifyonly',
-                    'cleanup1+defaults',
-                    'cleanup2+defaults'
+                    'cleanup1+defaults+notifyonly',
+                    'cleanup2+defaults+notifyonly'
                 ]
             )
         ]

--- a/manheim_c7n_tools/tests/test_policygen.py
+++ b/manheim_c7n_tools/tests/test_policygen.py
@@ -1610,6 +1610,9 @@ class TestGenerateConfigs(PolicyGenTester):
         def se_apply_defaults(klass, defaults, policy):
             return '%s+defaults' % policy
 
+        def se_notify_only(klass, policy):
+            return f'{policy}+notifyonly'
+
         policies = {
             'foo': 'bar',
             'baz': 'blam'
@@ -1620,17 +1623,19 @@ class TestGenerateConfigs(PolicyGenTester):
             _apply_defaults=DEFAULT,
             _generate_cleanup_policies=DEFAULT,
             _check_policies=DEFAULT,
-            _write_custodian_configs=DEFAULT
+            _write_custodian_configs=DEFAULT,
+            _handle_notify_only_policy=DEFAULT
         ) as mocks:
             mocks['_apply_defaults'].side_effect = se_apply_defaults
             mocks['_generate_cleanup_policies'].return_value = [
                 'cleanup1', 'cleanup2'
             ]
+            mocks['_handle_notify_only_policy'].side_effect = se_notify_only
             res = self.cls._generate_configs(policies, 'quux', 'region2')
         assert res == {
             'policies': [
-                'blam+defaults',
-                'bar+defaults',
+                'blam+defaults+notifyonly',
+                'bar+defaults+notifyonly',
                 'cleanup1+defaults',
                 'cleanup2+defaults'
             ]
@@ -1641,13 +1646,20 @@ class TestGenerateConfigs(PolicyGenTester):
             call(self.cls, 'quux', 'cleanup1'),
             call(self.cls, 'quux', 'cleanup2')
         ]
+        assert mocks['_handle_notify_only_policy'].mock_calls == [
+            call(self.cls, 'blam+defaults'),
+            call(self.cls, 'bar+defaults')
+        ]
         assert mocks['_generate_cleanup_policies'].mock_calls == [
-            call(self.cls, ['blam+defaults', 'bar+defaults'])
+            call(
+                self.cls,
+                ['blam+defaults+notifyonly', 'bar+defaults+notifyonly']
+            )
         ]
         exp_policies = {
             'policies': [
-                'blam+defaults',
-                'bar+defaults',
+                'blam+defaults+notifyonly',
+                'bar+defaults+notifyonly',
                 'cleanup1+defaults',
                 'cleanup2+defaults'
             ]
@@ -1659,8 +1671,8 @@ class TestGenerateConfigs(PolicyGenTester):
             call(
                 self.cls,
                 [
-                    'blam+defaults',
-                    'bar+defaults',
+                    'blam+defaults+notifyonly',
+                    'bar+defaults+notifyonly',
                     'cleanup1+defaults',
                     'cleanup2+defaults'
                 ]
@@ -1675,6 +1687,9 @@ class TestGenerateConfigs(PolicyGenTester):
         def se_apply_defaults(klass, defaults, policy):
             return '%s+defaults' % policy
 
+        def se_notify_only(klass, policy):
+            return f'{policy}+notifyonly'
+
         policies = {
             'foo': 'bar',
             'baz': 'blam'
@@ -1685,26 +1700,32 @@ class TestGenerateConfigs(PolicyGenTester):
             _apply_defaults=DEFAULT,
             _generate_cleanup_policies=DEFAULT,
             _check_policies=DEFAULT,
-            _write_custodian_configs=DEFAULT
+            _write_custodian_configs=DEFAULT,
+            _handle_notify_only_policy=DEFAULT
         ) as mocks:
             mocks['_apply_defaults'].side_effect = se_apply_defaults
             mocks['_generate_cleanup_policies'].return_value = []
+            mocks['_handle_notify_only_policy'].side_effect = se_notify_only
             res = self.cls._generate_configs(policies, 'quux', 'region2')
         assert res == {
             'policies': [
-                'blam+defaults',
-                'bar+defaults'
+                'blam+defaults+notifyonly',
+                'bar+defaults+notifyonly'
             ]
         }
         assert mocks['_apply_defaults'].mock_calls == [
             call(self.cls, 'quux', 'blam'),
             call(self.cls, 'quux', 'bar')
         ]
+        assert mocks['_handle_notify_only_policy'].mock_calls == [
+            call(self.cls, 'blam+defaults'),
+            call(self.cls, 'bar+defaults')
+        ]
         assert mocks['_generate_cleanup_policies'].mock_calls == []
         exp_policies = {
             'policies': [
-                'blam+defaults',
-                'bar+defaults'
+                'blam+defaults+notifyonly',
+                'bar+defaults+notifyonly'
             ]
         }
         assert mocks['_write_custodian_configs'].mock_calls == [
@@ -1714,8 +1735,8 @@ class TestGenerateConfigs(PolicyGenTester):
             call(
                 self.cls,
                 [
-                    'blam+defaults',
-                    'bar+defaults'
+                    'blam+defaults+notifyonly',
+                    'bar+defaults+notifyonly'
                 ]
             )
         ]

--- a/manheim_c7n_tools/tests/test_policygen.py
+++ b/manheim_c7n_tools/tests/test_policygen.py
@@ -2597,7 +2597,7 @@ class TestHandleNotifyOnlyPolicy(PolicyGenTester):
 
     def test_not_set(self):
         with patch(f'{pbm}.NotifyOnlyPolicy') as mock_nop:
-            mock_nop.as_notify_only.return_value = {
+            mock_nop.return_value.as_notify_only.return_value = {
                 'notify': 'only'
             }
             res = self.cls._handle_notify_only_policy({'my': 'policy'})
@@ -2606,7 +2606,7 @@ class TestHandleNotifyOnlyPolicy(PolicyGenTester):
 
     def test_false(self):
         with patch(f'{pbm}.NotifyOnlyPolicy') as mock_nop:
-            mock_nop.as_notify_only.return_value = {
+            mock_nop.return_value.as_notify_only.return_value = {
                 'notify': 'only'
             }
             res = self.cls._handle_notify_only_policy({
@@ -2622,14 +2622,14 @@ class TestHandleNotifyOnlyPolicy(PolicyGenTester):
             'notify_only': True
         }
         with patch(f'{pbm}.NotifyOnlyPolicy') as mock_nop:
-            mock_nop.as_notify_only.return_value = {
+            mock_nop.return_value.as_notify_only.return_value = {
                 'notify': 'only'
             }
 
             res = self.cls._handle_notify_only_policy(pol)
         assert res == {'notify': 'only'}
         assert mock_nop.mock_calls == [
-            call.as_notify_only(pol)
+            call(pol), call().as_notify_only()
         ]
 
 

--- a/manheim_c7n_tools/tests/test_policygen.py
+++ b/manheim_c7n_tools/tests/test_policygen.py
@@ -2593,6 +2593,46 @@ class TestGenerateCleanupPolicies(PolicyGenTester):
         ]
 
 
+class TestHandleNotifyOnlyPolicy(PolicyGenTester):
+
+    def test_not_set(self):
+        with patch(f'{pbm}.NotifyOnlyPolicy') as mock_nop:
+            mock_nop.as_notify_only.return_value = {
+                'notify': 'only'
+            }
+            res = self.cls._handle_notify_only_policy({'my': 'policy'})
+        assert res == {'my': 'policy'}
+        assert mock_nop.mock_calls == []
+
+    def test_false(self):
+        with patch(f'{pbm}.NotifyOnlyPolicy') as mock_nop:
+            mock_nop.as_notify_only.return_value = {
+                'notify': 'only'
+            }
+            res = self.cls._handle_notify_only_policy({
+                'my': 'policy',
+                'notify_only': False
+            })
+        assert res == {'my': 'policy'}
+        assert mock_nop.mock_calls == []
+
+    def test_true(self):
+        pol = {
+            'my': 'policy',
+            'notify_only': True
+        }
+        with patch(f'{pbm}.NotifyOnlyPolicy') as mock_nop:
+            mock_nop.as_notify_only.return_value = {
+                'notify': 'only'
+            }
+
+            res = self.cls._handle_notify_only_policy(pol)
+        assert res == {'notify': 'only'}
+        assert mock_nop.mock_calls == [
+            call.as_notify_only(pol)
+        ]
+
+
 class TestPolicyRst(PolicyGenTester):
 
     def test_rst_jenkins(self):

--- a/manheim_c7n_tools/tests/test_runner.py
+++ b/manheim_c7n_tools/tests/test_runner.py
@@ -624,11 +624,11 @@ class TestMailerStep(StepTester):
                 '%s.mailer_deploy.provision' % pbm, autospec=True
             ) as mock_prov:
                 with patch(
-                    '%s.functools.partial' % pbm, autospec=True
-                ) as mock_partial:
+                    '%s.session_factory' % pbm, autospec=True
+                ) as mock_sf:
                     with patch(
-                        '%s.session_factory' % pbm, autospec=True
-                    ) as mock_sf:
+                        '%s.functools.partial' % pbm, autospec=True
+                    ) as mock_partial:
                         mock_config.return_value = m_conf
                         mock_partial.return_value = m_partial
                         runner.MailerStep('rName', self.m_conf).run()
@@ -646,11 +646,11 @@ class TestMailerStep(StepTester):
                 '%s.mailer_deploy.provision' % pbm, autospec=True
             ) as mock_prov:
                 with patch(
-                    '%s.functools.partial' % pbm, autospec=True
-                ) as mock_partial:
+                    '%s.session_factory' % pbm, autospec=True
+                ):
                     with patch(
-                        '%s.session_factory' % pbm, autospec=True
-                    ):
+                        '%s.functools.partial' % pbm, autospec=True
+                    ) as mock_partial:
                         mock_config.return_value = m_conf
                         mock_partial.return_value = m_partial
                         runner.MailerStep('rName', self.m_conf).dryrun()

--- a/manheim_c7n_tools/tests/test_runner.py
+++ b/manheim_c7n_tools/tests/test_runner.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import sys
-from mock import patch, call, DEFAULT, Mock, PropertyMock
+from unittest.mock import patch, call, DEFAULT, Mock, PropertyMock
 import pytest
 from functools import partial
 

--- a/manheim_c7n_tools/tests/test_utils.py
+++ b/manheim_c7n_tools/tests/test_utils.py
@@ -23,7 +23,7 @@ from manheim_c7n_tools.utils import (
 )
 from manheim_c7n_tools.config import ManheimConfig
 
-from mock import patch, call, Mock, PropertyMock  # noqa
+from unittest.mock import patch, call, Mock, PropertyMock
 
 pbm = 'manheim_c7n_tools.utils'
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,6 @@ deps =
   pytest-pycodestyle
   pytest-flakes
   pytest-html
-  mock==3.0.5
   freezegun
   pytest-blockage
 

--- a/tox.ini
+++ b/tox.ini
@@ -46,7 +46,7 @@ setenv =
 deps =
   -rrequirements.txt
   -rdocs/requirements.txt
-basepython = python3.8
+basepython = python3.9
 commands_pre =
     # install c7n-mailer, which needs to be from source...
     #{toxinidir}/tox_install_mailer.sh {envdir}
@@ -65,7 +65,7 @@ commands =
 setenv =
     TOXINIDIR={toxinidir}
     TOXDISTDIR={distdir}
-basepython = python3.8
+basepython = python3.9
 commands =
     python --version
     virtualenv --version


### PR DESCRIPTION
## Description

This PR implements ``notify_only`` support for policies, which can also be used in ``defaults.yml`` to put an entire account into notify-only mode. This is controlled by a ``notify_only`` boolean top-level policy key, which policygen then handles and strips out when generating the final custodian YAML files.

The current functionality of notify-only is as follows:

-   The `comment` / `comments` / `description` fields will be prefixed with the string `NOTIFY ONLY:`
-   If the policy has a `tags` list, a `notify-only` tag will be appended to it.
-   All tagging actions will have the string `-notify-only` appended to their tag names, to automate the above-described transition. Specifically:
    -   Any `mark` or `tag` actions in the actions list will have the string `-notify-only` appended to their `tag` or `key` values (if present) or appended to every item in their `tags` list (if present). If none of the above are present, the `tag` item will be set to custodian's `DEFAULT_TAG` value, with `-notify-only` appended.
    -   Any `mark-for-op` actions will have the string `-notify-only` appended to their `tag` value. If they do not already have a `tag` value, it will be set to custodian's `DEFAULT_TAG` value, with `-notify-only` appended.
    - Any `remove-tag` / `unmark` / `untag` actions wukk have the string `-notify-only` appended to all items in their `tags` list.
-   All `notify` actions will have their `violation_desc`, if present, prefixed with `NOTIFY ONLY:`. Their `action_desc`, if present, will be prefixed with `in the future (currently notify-only)`.
- All other action types, not listed above, will be **removed from the policy**. We enforce notify-only by only retaining specifically whitelisted actions in the policy.

## Testing Done

1. Complete unit test coverage.
2. Ran a dry-run internally on one of our accounts. Ping me on Slack, or see the card for this, for a link to the diff.