### PR TITLE
update README for migration to travis-ci.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ manheim-c7n-tools
 
 [![ReadTheDocs.org build status](https://readthedocs.org/projects/manheim-c7n-tools/badge/?version=latest)](https://manheim-c7n-tools.readthedocs.io/)
 
-[![TravisCI build badge](https://api.travis-ci.org/manheim/manheim-c7n-tools.png?branch=master)](https://travis-ci.org/manheim/manheim-c7n-tools)
+[![TravisCI build badge](https://api.travis-ci.com/manheim/manheim-c7n-tools.svg?branch=master)](https://travis-ci.com/github/manheim/manheim-c7n-tools)
 
 [![Docker Hub Build Status](https://img.shields.io/docker/cloud/build/manheim/manheim-c7n-tools.svg)](https://hub.docker.com/r/manheim/manheim-c7n-tools)
 
@@ -14,7 +14,7 @@ Manheim's Cloud Custodian (c7n) wrapper package, policy generator, runner, and s
 This project provides common tooling, distributed as a Docker image, for managing Manheim's cloud-custodian (c7n) tooling, including c7n itself, c7n_mailer, and our custom components. This project/repository is intended to be used (generally via the generated Docker image) alongside a configuration repository of a specific layout, containing configuration for one or more AWS accounts.
 
 * **Full Documentation**: <https://manheim-c7n-tools.readthedocs.io/>
-* TravisCI Builds: <https://travis-ci.org/manheim/manheim-c7n-tools>
+* TravisCI Builds: <https://travis-ci.com/github/manheim/manheim-c7n-tools>
 * Docker image: <https://hub.docker.com/r/manheim/manheim-c7n-tools>
 
 For documentation on the upstream cloud-custodian project, please see <https://cloudcustodian.io/docs/index.html> and the source code at <https://github.com/cloud-custodian/cloud-custodian>.


### PR DESCRIPTION
## Description

travis-ci.org is being shut down. I've migrated this repo from .org to .com. This PR updates the README accordingly.

## Testing Done

travis-ci.com tests