### PR TITLE
Bump c7n and c7n-mailer to latest

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,11 @@ Changelog
 =========
 
 
+Unreleased
+------------------
+
+* Fixes `#63 <https://github.com/manheim/manheim-c7n-tools/issues/63>`__ - Bump c7n version from 0.9.10 to `0.9.14 <https://github.com/cloud-custodian/cloud-custodian/releases/tag/0.9.14.0>`__ and c7n-mailer from 0.6.9 to 0.6.13.
+
 1.3.1 (2021-06-14)
 ------------------
 

--- a/manheim_c7n_tools/version.py
+++ b/manheim_c7n_tools/version.py
@@ -17,7 +17,7 @@ manheim-c7n-tools version configuration.
 """
 
 #: The semver-compliant version of the package.
-VERSION = '1.3.1'
+VERSION = '1.3.2'
 
 #: The URL for further information about the package.
 PROJECT_URL = 'https://github.com/manheim/manheim-c7n-tools'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-c7n==0.9.10
-c7n-mailer==0.6.9
+c7n==0.9.14
+c7n-mailer==0.6.13
 tabulate>=0.8.0,<0.9.0
 # In order to work with the "mu" Lambda function management tool,
 # we need PyYAML 3.x, and need it as source and not a wheel


### PR DESCRIPTION
This PR fixes #63 by bumping both c7n and c7n-mailer to their latest upstream releases. 