### PR TITLE
feat: add python 3.12 support

### DIFF
--- a/.github/workflows/pr.workflow.yml
+++ b/.github/workflows/pr.workflow.yml
@@ -64,6 +64,26 @@ jobs:
       - run: virtualenv --version
       - run: tox -r
       - run: codecov
+  test-py312:
+    env:
+      TOXENV: py312
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.12'
+          architecture: 'x64'
+      - run: pip install virtualenv
+      - run: virtualenv --version
+      - run: git config --global user.email "man-releaseengineering@manheim.com"
+      - run: git config --global user.name "Manheim RE"
+      - run: pip install tox
+      - run: pip install codecov
+      - run: pip freeze
+      - run: virtualenv --version
+      - run: tox -r
+      - run: codecov
   test-docs:
     env:
       TOXENV: docs
@@ -72,7 +92,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.9'
+          python-version: '3.12'
           architecture: 'x64'
       - run: pip install virtualenv
       - run: virtualenv --version
@@ -92,7 +112,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.9'
+          python-version: '3.12'
           architecture: 'x64'
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -107,7 +127,7 @@ jobs:
       - run: tox -r
       - run: codecov
   pypi-build:
-    needs: [test-py37, test-py38, test-py39, test-docs, test-docker]
+    needs: [test-py37, test-py38, test-py39, test-py312, test-docs, test-docker]
     env:
       TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
       TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
@@ -116,7 +136,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.9'
+          python-version: '3.12'
           architecture: 'x64'
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1

--- a/.github/workflows/pr.workflow.yml
+++ b/.github/workflows/pr.workflow.yml
@@ -4,26 +4,6 @@ on: # rebuild any PR changes
   pull_request:
     branches: [ master ]
 jobs:
-  test-py37:
-    env:
-      TOXENV: py37
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.7'
-          architecture: 'x64'
-      - run: pip install virtualenv
-      - run: virtualenv --version
-      - run: git config --global user.email "man-releaseengineering@manheim.com"
-      - run: git config --global user.name "Manheim RE"
-      - run: pip install tox
-      - run: pip install codecov
-      - run: pip freeze
-      - run: virtualenv --version
-      - run: tox -r
-      - run: codecov
   test-py38:
     env:
       TOXENV: py38
@@ -127,7 +107,7 @@ jobs:
       - run: tox -r
       - run: codecov
   pypi-build:
-    needs: [test-py37, test-py38, test-py39, test-py312, test-docs, test-docker]
+    needs: [test-py38, test-py39, test-py312, test-docs, test-docker]
     env:
       TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
       TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}

--- a/.github/workflows/release.workflow.yml
+++ b/.github/workflows/release.workflow.yml
@@ -5,26 +5,6 @@ on: # Build and release when creating new tags
     tags:
       - '*'
 jobs:
-  test-py37:
-    env:
-      TOXENV: py37
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        with:
-          python-version: '3.7'
-          architecture: 'x64'
-      - run: pip install virtualenv
-      - run: virtualenv --version
-      - run: git config --global user.email "man-releaseengineering@manheim.com"
-      - run: git config --global user.name "Manheim RE"
-      - run: pip install tox
-      - run: pip install codecov
-      - run: pip freeze
-      - run: virtualenv --version
-      - run: tox -r
-      - run: codecov
   test-py38:
     env:
       TOXENV: py38
@@ -128,7 +108,7 @@ jobs:
       - run: tox -r
       - run: codecov
   pypi-deploy:
-    needs: [test-py37, test-py38, test-py39, test-py312, test-docs, test-docker]
+    needs: [test-py38, test-py39, test-py312, test-docs, test-docker]
     env:
       TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
       TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}

--- a/.github/workflows/release.workflow.yml
+++ b/.github/workflows/release.workflow.yml
@@ -65,6 +65,26 @@ jobs:
       - run: virtualenv --version
       - run: tox -r
       - run: codecov
+  test-py12:
+    env:
+      TOXENV: py12
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.12'
+          architecture: 'x64'
+      - run: pip install virtualenv
+      - run: virtualenv --version
+      - run: git config --global user.email "man-releaseengineering@manheim.com"
+      - run: git config --global user.name "Manheim RE"
+      - run: pip install tox
+      - run: pip install codecov
+      - run: pip freeze
+      - run: virtualenv --version
+      - run: tox -r
+      - run: codecov
   test-docs:
     env:
       TOXENV: docs
@@ -73,7 +93,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.9'
+          python-version: '3.12'
           architecture: 'x64'
       - run: pip install virtualenv
       - run: virtualenv --version
@@ -93,7 +113,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.9'
+          python-version: '3.12'
           architecture: 'x64'
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
@@ -108,7 +128,7 @@ jobs:
       - run: tox -r
       - run: codecov
   pypi-deploy:
-    needs: [test-py37, test-py38, test-py39, test-docs, test-docker]
+    needs: [test-py37, test-py38, test-py39, test-py312, test-docs, test-docker]
     env:
       TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
       TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
@@ -117,7 +137,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.9'
+          python-version: '3.12'
           architecture: 'x64'
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Changelog
 
 * Bump c7n to release 0.9.37
 * Bump c7n-mailer to release 0.6.36
+* Drop python 3.7
 * Add python 3.12
 
 1.4.3 (2022-05-24)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+1.5.0 (2024-06-10)
+------------------
+
+* Bump c7n to release 0.9.37
+* Bump c7n-mailer to release 0.6.36
+* Add python 3.12
+
 1.4.3 (2022-05-24)
 ------------------
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.1-alpine3.12
+FROM python:3.12-alpine
 
 ARG git_version
 
@@ -12,6 +12,8 @@ RUN cd /manheim_c7n_tools \
       musl-dev \
       libffi-dev \
       openssl-dev \
+      rust \
+      cargo \
   && pip install -r requirements.txt \
   && pip install -e . \
   # clean up build dependencies

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,3 +1,4 @@
-sut:
-  build: .
-  command: bash -c "policygen -V && s3-archiver -V && dryrun-diff -V && manheim-c7n-runner -V && mugc --help && errorscan -V"
+services:
+  sut:
+    build: .
+    command: bash -c "policygen -V && s3-archiver -V && dryrun-diff -V && manheim-c7n-runner -V && mugc --help && errorscan -V"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-c7n==0.9.16
-c7n-mailer==0.6.15
-tabulate>=0.8.0,<0.9.0
+c7n==0.9.37
+c7n-mailer==0.6.36
+tabulate
 # In order to work with the "mu" Lambda function management tool,
 # we need PyYAML 3.x, and need it as source and not a wheel
 pyyaml

--- a/setup.py
+++ b/setup.py
@@ -8,12 +8,12 @@ requires = [
     'boto3',
     'botocore',
     'docutils',
-    'tabulate>=0.8.0,<0.9.0',
+    'tabulate',
     # In order to work with the "mu" Lambda function management tool,
     # we need PyYAML 3.x, and need it as source and not a wheel
     'pyyaml',
-    'c7n==0.9.16',
-    'c7n-mailer==0.6.15',
+    'c7n==0.9.37',
+    'c7n-mailer==0.6.36',
     # for building generated policy docs
     'sphinx',
     'sphinx_rtd_theme',

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,7 @@ setenv =
 deps =
   -rrequirements.txt
   -rdocs/requirements.txt
-basepython = python3.9
+basepython = python3.12
 commands_pre =
     # install c7n-mailer, which needs to be from source...
     #{toxinidir}/tox_install_mailer.sh {envdir}
@@ -69,7 +69,7 @@ commands =
 setenv =
     TOXINIDIR={toxinidir}
     TOXDISTDIR={distdir}
-basepython = python3.9
+basepython = python3.12
 commands =
     python --version
     virtualenv --version

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,10 @@ commands =
 
 [testenv:docs]
 # this really just makes sure README.rst will parse on pypi
-passenv = CONTINUOUS_INTEGRATION AWS* READTHEDOCS*
+passenv = 
+    CONTINUOUS_INTEGRATION 
+    AWS* 
+    READTHEDOCS*
 setenv =
     TOXINIDIR={toxinidir}
     TOXDISTDIR={distdir}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = python3.7,python3.8,py39,py312,docs,docker
+envlist = python3.8,py39,py312,docs,docker
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = python3.7,python3.8,py39,docs,docker
+envlist = python3.7,python3.8,py39,py312,docs,docker
 
 [testenv]
 deps =


### PR DESCRIPTION

## Description

Adds python 3.12 support and updates c7n dependencies to latest

## Testing Done

Tested locally with docker

## Important Notes

_Optional; instructions to reviewers, plans for how to release this, dependencies in other repos, etc._

## Contributor License Agreement

Required for external contributors.

By submitting this work for inclusion in manheim-c7n-tools, I agree to the following terms:

* The contribution included in this request (and any subsequent revisions or versions of it)
  is being made under the same license as the manheim-c7n-tools project (Apache v2).
* My contribution may perpetually be included in and distributed with manheim-c7n-tools; submitting
  this pull request grants a perpetual, global, unlimited license for it to be used and distributed
  under the terms of manheim-c7n-tools's license.
* I have the legal power and rights to agree to these terms.
